### PR TITLE
JSF PostRestoreEvent to be delivered from JsfViewFactory

### DIFF
--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JSFMockHelper.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JSFMockHelper.java
@@ -28,13 +28,14 @@ import org.apache.myfaces.test.mock.MockServletConfig;
 import org.apache.myfaces.test.mock.MockServletContext;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycle;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycleFactory;
+import org.apache.myfaces.test.mock.visit.MockVisitContextFactory;
 
 /**
  * Helper for using the mock JSF environment provided by shale-test inside unit tests that do not extend
  * {@link AbstractJsfTestCase}
  * 
  * @author Jeremy Grelle
- * @author Phil Webb
+ * @author Phillip Webb
  */
 public class JSFMockHelper {
 
@@ -137,7 +138,9 @@ public class JSFMockHelper {
 			FactoryFinder.setFactory(FactoryFinder.FACES_CONTEXT_FACTORY, MockBaseFacesContextFactory.class.getName());
 			FactoryFinder.setFactory(FactoryFinder.LIFECYCLE_FACTORY, MockLifecycleFactory.class.getName());
 			FactoryFinder.setFactory(FactoryFinder.RENDER_KIT_FACTORY, MockRenderKitFactory.class.getName());
-			FactoryFinder.setFactory(FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY, MockPartialViewContextFactory.class.getName());
+			FactoryFinder.setFactory(FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY,
+					MockPartialViewContextFactory.class.getName());
+			FactoryFinder.setFactory(FactoryFinder.VISIT_CONTEXT_FACTORY, MockVisitContextFactory.class.getName());
 			lifecycleFactory = (MockLifecycleFactory) FactoryFinder.getFactory(FactoryFinder.LIFECYCLE_FACTORY);
 			lifecycle = (MockLifecycle) lifecycleFactory.getLifecycle(LifecycleFactory.DEFAULT_LIFECYCLE);
 			facesContextFactory = (FacesContextFactory) FactoryFinder.getFactory(FactoryFinder.FACES_CONTEXT_FACTORY);

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/MockBaseFacesContext.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/MockBaseFacesContext.java
@@ -38,4 +38,8 @@ public class MockBaseFacesContext extends MockFacesContext20 {
 		}
 		return application;
 	}
+
+	public void setApplication(Application application) {
+		this.application = application;
+	}
 }


### PR DESCRIPTION
The PostRestoreStateEvent should be delivered whenever a JSF view is restored.  The Mojarra RestoreViewPhase class usually takes care of this but since WebFlow handles the RESTORE_VIEW phase itself we need to ensure that we also send this message.  System Events were added in JSF 2.0.

Issues: SWF-1500
