### PR TITLE
Deprecate CompositeIterator in favor Spring core.

### DIFF
--- a/spring-binding/src/main/java/org/springframework/binding/collection/CompositeIterator.java
+++ b/spring-binding/src/main/java/org/springframework/binding/collection/CompositeIterator.java
@@ -27,7 +27,9 @@ import org.springframework.util.Assert;
  * iterators which are invoked in sequence untill all iterators are exhausted.
  * 
  * @author Erwin Vervaet
+ * @deprecated in favor of {@link org.springframework.util.CompositeIterator}
  */
+@Deprecated
 public class CompositeIterator<E> implements Iterator<E> {
 
 	private List<Iterator<E>> iterators = new LinkedList<Iterator<E>>();

--- a/spring-binding/src/test/java/org/springframework/binding/collection/CompositeIteratorTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/collection/CompositeIteratorTests.java
@@ -27,6 +27,7 @@ import junit.framework.TestCase;
  * 
  * @author Erwin Vervaet
  */
+@Deprecated
 public class CompositeIteratorTests extends TestCase {
 
 	public void testNoIterators() {

--- a/spring-webflow/src/main/java/org/springframework/webflow/context/portlet/PortletRequestParameterMap.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/context/portlet/PortletRequestParameterMap.java
@@ -19,9 +19,9 @@ import java.util.Iterator;
 
 import javax.portlet.PortletRequest;
 
-import org.springframework.binding.collection.CompositeIterator;
 import org.springframework.binding.collection.StringKeyedMapAdapter;
 import org.springframework.util.Assert;
+import org.springframework.util.CompositeIterator;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.portlet.multipart.MultipartActionRequest;
 import org.springframework.webflow.core.collection.CollectionUtils;

--- a/spring-webflow/src/main/java/org/springframework/webflow/context/servlet/HttpServletRequestParameterMap.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/context/servlet/HttpServletRequestParameterMap.java
@@ -19,9 +19,9 @@ import java.util.Iterator;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.springframework.binding.collection.CompositeIterator;
 import org.springframework.binding.collection.StringKeyedMapAdapter;
 import org.springframework.util.Assert;
+import org.springframework.util.CompositeIterator;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.webflow.core.collection.CollectionUtils;
 


### PR DESCRIPTION
Deprecate existing class and refactor internal code to use the org.spring.util version that 
has been available since Spring 3.0

Issues: SWF-1532
