### PR TITLE
add jboss repositpory

### DIFF
--- a/spring-binding/pom.xml
+++ b/spring-binding/pom.xml
@@ -82,6 +82,14 @@
  			<id>maven2.java.net</id>
  			<url>http://download.java.net/maven/2</url>
 		</repository>
+	<!-- Where the el-api implementation is located -->
+        <repository>
+            <id>repository.jboss.org</id>
+            <url>http://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
 	</repositories>	
 	<build>
 		<plugins>

--- a/spring-faces/pom.xml
+++ b/spring-faces/pom.xml
@@ -155,6 +155,15 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<repositories>
+        <repository>
+            <id>repository.jboss.org</id>
+            <url>http://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 	<build>
 		<plugins>
 			<plugin>

--- a/spring-webflow/pom.xml
+++ b/spring-webflow/pom.xml
@@ -192,6 +192,14 @@
  			<id>maven2.java.net</id>
  			<url>http://download.java.net/maven/2</url>
 		</repository>
+	<!-- Where the el-api implementation is located -->
+        <repository>
+            <id>repository.jboss.org</id>
+            <url>http://repository.jboss.org/nexus/content/groups/public-jboss</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
 	</repositories>
 	<build>
 		<plugins>


### PR DESCRIPTION
Indeed jboss el and richfaces dependencies are currently not found, which breaks the maven build.
This simple fix allows anyone to compile and install webflow (using maven).
