### PR TITLE
Modify <faces:resources> to add portlet variant

### DIFF
--- a/spring-faces/src/main/java/org/springframework/faces/webflow/JsfRuntimeInformation.java
+++ b/spring-faces/src/main/java/org/springframework/faces/webflow/JsfRuntimeInformation.java
@@ -42,7 +42,13 @@ public class JsfRuntimeInformation {
 
 	private static final int jsfVersion;
 
-	private static final boolean myFacesPresent = ClassUtils.isPresent("org.apache.myfaces.webapp.MyFacesServlet", JsfUtils.class.getClassLoader());
+	private static final ClassLoader CLASS_LOADER = JsfUtils.class.getClassLoader();
+
+	private static final boolean myFacesPresent = ClassUtils.isPresent("org.apache.myfaces.webapp.MyFacesServlet", CLASS_LOADER);
+
+	private static boolean portletPresent = ClassUtils.isPresent("javax.portlet.Portlet", CLASS_LOADER);
+	
+	private static boolean springPortletPresent = ClassUtils.isPresent("org.springframework.web.portlet.DispatcherPortlet", CLASS_LOADER);
 
 	static {
 		if (ReflectionUtils.findMethod(FacesContext.class, "isPostback") != null) {
@@ -80,6 +86,15 @@ public class JsfRuntimeInformation {
 
 	public static boolean isMyFacesPresent() {
 		return myFacesPresent;
+	}
+
+	/**
+	 * Determines if the container has support for portlets and if Spring MVC portlet support is available
+	 * 
+	 * @return <tt>true</tt> if a portlet environment is detected
+	 */
+	public static boolean isSpringPortletPresent() {
+		return portletPresent && springPortletPresent;
 	}
 
 	/**

--- a/spring-faces/src/test/java/org/springframework/faces/config/ResourcesBeanDefinitionParserTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/config/ResourcesBeanDefinitionParserTests.java
@@ -24,16 +24,21 @@ public class ResourcesBeanDefinitionParserTests extends TestCase {
 		Map<String, ?> map = this.context.getBeansOfType(HttpRequestHandlerAdapter.class);
 		assertEquals(1, map.values().size());
 
-		Object resourceHandler = this.context.getBean(ResourcesBeanDefinitionParser.RESOURCE_HANDLER_BEAN_NAME);
+		Object resourceHandler = this.context.getBean(ResourcesBeanDefinitionParser.SERVLET_RESOURCE_HANDLER_BEAN_NAME);
 		assertNotNull(resourceHandler);
 		assertTrue(resourceHandler instanceof JsfResourceRequestHandler);
 
 		map = this.context.getBeansOfType(SimpleUrlHandlerMapping.class);
 		assertEquals(1, map.values().size());
 		SimpleUrlHandlerMapping handlerMapping = (SimpleUrlHandlerMapping) map.values().iterator().next();
-		assertEquals(ResourcesBeanDefinitionParser.RESOURCE_HANDLER_BEAN_NAME,
+		assertEquals(ResourcesBeanDefinitionParser.SERVLET_RESOURCE_HANDLER_BEAN_NAME,
 				handlerMapping.getUrlMap().get("/javax.faces.resource/**"));
 		assertEquals(0, handlerMapping.getOrder());
 	}
-
+	
+	public void testConfigurePortlet() {
+		Object resourceHandler = this.context.getBean(ResourcesBeanDefinitionParser.PORTLET_RESOURCE_HANDLER_BEAN_NAME);
+		assertNotNull(resourceHandler);
+		assertTrue(resourceHandler instanceof org.springframework.faces.webflow.context.portlet.JsfResourceRequestHandler);
+	}
 }


### PR DESCRIPTION
The ResourcesBeanDefinitionParser will now automatically register an
additional portlet resource resolver when a portlet environment and
and relevant Spring portlet classes are detected.

Issues: SWF-1500
