### PR TITLE
Save Web Flow output to MVC flash scope

### DIFF
--- a/src/reference/spring-mvc.xml
+++ b/src/reference/spring-mvc.xml
@@ -469,6 +469,31 @@ mvn package
 # import into Eclipse</programlisting>
 		</para>
 	</sect2>
-
   </sect1>
+
+  <sect1 id="spring-mvc-flash-output">
+    <title>Saving Flow Output to MVC Flash Scope</title>
+      <para>Flow output can be automatically saved to MVC flash scope when an <code>end-state</code> 
+      performs an internal redirect. This is particularly useful when displaying a summary 
+      screen at the end of a flow. For backwards compatibility this feature is disabled by 
+      default, to enable set <code>saveOutputToFlashScopeOnRedirect</code> on your 
+      <code>FlowHandlerAdapter</code> to <code>true</code>.</para>
+
+      <programlisting language="xml">
+&lt;!-- Enables FlowHandler URL mapping --&gt;
+&lt;bean class="org.springframework.webflow.mvc.servlet.FlowHandlerAdapter"&gt;
+    &lt;property name="flowExecutor" ref="flowExecutor" /&gt;
+    &lt;property name="saveOutputToFlashScopeOnRedirect" value="true" /&gt;
+&lt;/bean&gt;
+      </programlisting>
+
+      <para>The following example will add <code>confirmationNumber</code> to the MVC flash scope
+      before redirecting to the <code>summary</code> screen.</para>
+
+      <programlisting language="xml">
+&lt;end-state id="finish" view="externalRedirect:summary"&gt;
+    &lt;output name="confirmationNumber" value="booking.confirmationNumber" /&gt;
+&lt;/end-state&gt;
+      </programlisting>
+    </sect1>
 </chapter>

--- a/src/reference/whatsnew.xml
+++ b/src/reference/whatsnew.xml
@@ -23,6 +23,12 @@
 				included as part of their Spring configuration. See <xref linkend="portlet-jsf"/>.
 			</para>
 		</sect2>
+		<sect2 id="whatsnew-swf-mvcflash">
+			<title>Saving Flow Output to Spring MVC Flash Scope</title>
+			<para>
+				Flow output can now be saved to Spring MVC Flash Scope for any <code>end-state</code> that issues an internal redirect.  To enable this feature set <code>FlowHandlerAdapter.saveOutputToFlashScopeOnRedirect</code>.  See <xref linkend="spring-mvc-flash-output"/>.
+			</para>
+		</sect2>
 	</sect1>
 	<sect1 id="whatsnew-swf-230">
 		<title>Spring Web Flow 2.3</title>


### PR DESCRIPTION
Output from a flow can now be saved to the flash scope of Spring MVC
when the 'saveOutputToFlashScopeOnRedirect' property of the
FlowHandlerAdapter is 'true'.

For backwards compatibility this is an opt-in feature that must be
configured by the user.

Issues: SWF-1561
