### PR TITLE
Add support for partial validation with JSR-303

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilder.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilder.java
@@ -114,7 +114,7 @@ import org.springframework.webflow.security.SecurityRule;
 
 /**
  * Builds a runtime {@link Flow} definition object from a {@link FlowModel}.
- * 
+ *
  * @author Keith Donald
  */
 public class FlowModelFlowBuilder extends AbstractFlowBuilder {
@@ -533,6 +533,11 @@ public class FlowModelFlowBuilder extends AbstractFlowBuilder {
 			attributes.put(
 					"model",
 					getLocalContext().getExpressionParser().parseExpression(state.getModel(),
+							new FluentParserContext().evaluate(RequestContext.class)));
+		}
+		if (state.getValidationHints() != null) {
+			attributes.put("validationHints",
+					getLocalContext().getExpressionParser().parseExpression(state.getValidationHints(),
 							new FluentParserContext().evaluate(RequestContext.class)));
 		}
 		parseAndPutSecured(state.getSecured(), attributes);

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/AbstractModel.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/AbstractModel.java
@@ -18,9 +18,11 @@ package org.springframework.webflow.engine.model;
 import java.util.Collections;
 import java.util.LinkedList;
 
+import org.springframework.util.StringUtils;
+
 /**
  * Contains basic merge functions that can be utilized by other models.
- * 
+ *
  * @author Scott Andrews
  */
 public abstract class AbstractModel implements Model {
@@ -106,6 +108,26 @@ public abstract class AbstractModel implements Model {
 			addOrMerge(child, parentModel, addAtEnd);
 		}
 		return child;
+	}
+
+	/**
+	 * Merge validation hints by taking the union of both with the child validation hints listed first.
+	 * @param child child validation hints
+	 * @param parent parent validation hints
+	 * @return the merged hints or {@code null}
+	 */
+	protected String mergeValidationHints(String child, String parent) {
+		StringBuilder sb = new StringBuilder();
+		if (StringUtils.hasText(child)) {
+			sb.append(child);
+		}
+		if (StringUtils.hasText(parent)) {
+			if (sb.length() > 0) {
+				sb.append(",");
+			}
+			sb.append(parent);
+		}
+		return (sb.length() > 0) ? sb.toString() : null;
 	}
 
 	private <T extends Model> void addOrMerge(LinkedList<T> list, T modelToMerge, boolean addAtEnd) {

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/ViewStateModel.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/ViewStateModel.java
@@ -22,7 +22,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Model support for view states.
- * 
+ *
  * @author Scott Andrews
  */
 public class ViewStateModel extends AbstractTransitionableStateModel {
@@ -34,6 +34,8 @@ public class ViewStateModel extends AbstractTransitionableStateModel {
 	private String popup;
 
 	private String model;
+
+	private String validationHints;
 
 	private LinkedList<VarModel> vars;
 
@@ -70,6 +72,7 @@ public class ViewStateModel extends AbstractTransitionableStateModel {
 		setRedirect(merge(getRedirect(), state.getRedirect()));
 		setPopup(merge(getPopup(), state.getPopup()));
 		setModel(merge(getModel(), state.getModel()));
+		setValidationHints(mergeValidationHints(getValidationHints(), state.getValidationHints()));
 		setVars(merge(getVars(), state.getVars(), false));
 		setBinder((BinderModel) merge(getBinder(), state.getBinder()));
 		setOnRenderActions(merge(getOnRenderActions(), state.getOnRenderActions(), false));
@@ -82,6 +85,7 @@ public class ViewStateModel extends AbstractTransitionableStateModel {
 		copy.setRedirect(redirect);
 		copy.setPopup(popup);
 		copy.setModel(model);
+		copy.setValidationHints(validationHints);
 		copy.setVars(copyList(vars));
 		copy.setBinder((BinderModel) copy(binder));
 		copy.setOnRenderActions(copyList(onRenderActions));
@@ -157,6 +161,19 @@ public class ViewStateModel extends AbstractTransitionableStateModel {
 			this.model = model;
 		} else {
 			this.model = null;
+		}
+	}
+
+	public String getValidationHints() {
+		return validationHints;
+	}
+
+	public void setValidationHints(String validationHints) {
+		if (StringUtils.hasText(validationHints)) {
+			this.validationHints = validationHints;
+		}
+		else {
+			this.validationHints = null;
 		}
 	}
 

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolver.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolver.java
@@ -27,7 +27,7 @@ import org.xml.sax.SAXException;
  * EntityResolver implementation for the Spring Web Flow XML Schema. This will load the XSD from the classpath.
  * <p>
  * The xmlns of the XSD expected to be resolved:
- * 
+ *
  * <pre>
  *     &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
  *     &lt;flow xmlns=&quot;http://www.springframework.org/schema/webflow&quot;
@@ -35,13 +35,13 @@ import org.xml.sax.SAXException;
  *           xsi:schemaLocation=&quot;http://www.springframework.org/schema/webflow
  *                               http://www.springframework.org/schema/webflow/spring-webflow.xsd&quot;&gt;
  * </pre>
- * 
+ *
  * @author Erwin Vervaet
  * @author Ben Hale
  */
 class WebFlowEntityResolver implements EntityResolver {
 
-	private static final String[] WEBFLOW_VERSIONS = new String[] { "spring-webflow-2.0" };
+	private static final String[] WEBFLOW_VERSIONS = new String[] { "spring-webflow-2.4", "spring-webflow-2.0" };
 
 	public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
 		if (systemId != null && systemId.indexOf("spring-webflow.xsd") > -1) {

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilder.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilder.java
@@ -60,7 +60,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Builds a flow model from a XML-based flow definition resource.
- * 
+ *
  * @author Keith Donald
  * @author Scott Andrews
  */
@@ -570,6 +570,7 @@ public class XmlFlowModelBuilder implements FlowModelBuilder {
 		state.setRedirect(element.getAttribute("redirect"));
 		state.setPopup(element.getAttribute("popup"));
 		state.setModel(element.getAttribute("model"));
+		state.setValidationHints(element.getAttribute("validation-hints"));
 		state.setVars(parseVars(element));
 		state.setBinder(parseBinder(element));
 		state.setOnRenderActions(parseOnRenderActions(element));

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/package-info.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/package-info.java
@@ -18,7 +18,7 @@
  * Defines the XmlFlowModelBuilder, for building FlowModels from XML-based resources.
  *
  * <p>This package also contains the definition of the XML-based flow definition language, defined within
- * {@code spring-webflow-2.0.xsd}.  See this schema for a detailed description of language elements.
+ * {@code spring-webflow-2.4.xsd}.  See this schema for a detailed description of language elements.
  */
 package org.springframework.webflow.engine.model.builder.xml;
 

--- a/spring-webflow/src/main/java/org/springframework/webflow/validation/DefaultValidationHintResolver.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/validation/DefaultValidationHintResolver.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2008-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.webflow.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.webflow.execution.FlowExecutionException;
+
+/**
+ * Default implementation of {@link ValidationHintResolver} that tries to resolve
+ * expects each hint to be either a Class name or the name of an inner Class found
+ * in the Class of the model or any of its super classes.
+ *
+ * @author Rossen Stoyanchev
+ * @since 2.4
+ */
+public class DefaultValidationHintResolver implements ValidationHintResolver {
+
+	public Object[] resolveValidationHints(Object model, String flowId, String stateId, String[] hints) {
+
+		hints = ObjectUtils.addObjectToArray(hints, StringUtils.capitalize(stateId));
+
+		List<Object> result = new ArrayList<Object>();
+		for (String hint : hints) {
+			Class<?> typeHint = toClass(hint);
+			if (typeHint == null) {
+				typeHint = findInnerClass(model.getClass(), hint);
+			}
+			if (typeHint != null) {
+				result.add(typeHint);
+			}
+			else {
+				handleUnresolvedHint(model, flowId, stateId, hint);
+			}
+		}
+
+		return result.toArray();
+	}
+
+	private Class<?> toClass(String hint) {
+		try {
+			return Class.forName(hint);
+		}
+		catch (ClassNotFoundException e) {
+			// Ignore
+		}
+		return null;
+	}
+
+	private Class<?> findInnerClass(Class<?> targetClass, String hint) {
+		try {
+			return Class.forName(targetClass.getName() + "$" + hint);
+		}
+		catch (ClassNotFoundException e) {
+			Class<?> superClass = targetClass.getSuperclass();
+			if (superClass != null) {
+				return findInnerClass(superClass, hint);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Invoked when a hint could not be resolved. This implementation raises a
+	 * {@link FlowExecutionException}.
+	 *
+	 * @param model the model object that will be validated using the hints
+	 * @param flowId the current flow id
+	 * @param stateId the current state id
+	 * @param hint the hint
+	 *
+	 * @throws FlowExecutionException
+	 */
+	protected void handleUnresolvedHint(Object model, String flowId, String stateId, String hint) {
+		if (!stateId.equalsIgnoreCase(hint)) {
+			throw new FlowExecutionException(flowId, stateId, "Failed to resolve validation hint [" + hint + "]");
+		}
+	}
+
+}

--- a/spring-webflow/src/main/java/org/springframework/webflow/validation/ValidationHelper.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/validation/ValidationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,13 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.MessageCodesResolver;
+import org.springframework.validation.SmartValidator;
 import org.springframework.validation.Validator;
 import org.springframework.webflow.execution.RequestContext;
 
 /**
  * A helper class the encapsulates conventions to invoke validation logic.
- * 
+ *
  * @author Scott Andrews
  * @author Canny Duck
  * @author Jeremy Grelle
@@ -65,6 +66,11 @@ public class ValidationHelper {
 
 	private Validator validator;
 
+	private String[] validationHints;
+
+	private ValidationHintResolver validationHintResolver = new DefaultValidationHintResolver();
+
+
 	/**
 	 * Create a throwaway validation helper object. Validation is invoked by the {@link #validate()} method.
 	 * <p>
@@ -74,7 +80,7 @@ public class ValidationHelper {
 	 * <p>
 	 * For example: <code>model.validateEnterBookingDetails(VaticationContext)</code> or
 	 * <code>context.getBean("modelValidator").validateEnterBookingDetails(model, VaticationContext)</code>
-	 * 
+	 *
 	 * @param model the object to validate
 	 * @param requestContext the context for the request
 	 * @param eventId the event triggering validation
@@ -103,16 +109,32 @@ public class ValidationHelper {
 	}
 
 	/**
+	 * Provide validation hints such as validation groups against a JSR-303 provider.
+	 */
+	public void setValidationHints(String[] validationHints) {
+		this.validationHints = validationHints;
+	}
+
+	/**
+	 * Configure a {@link ValidationHintResolver} to use to resolve String based validation
+	 * hints into Object hints such as validation groups against a JSR-303 provider.
+	 * <p>If not set, a {@link DefaultValidationHintResolver} is created.
+	 */
+	public void setValidationHintResolver(ValidationHintResolver validationHintResolver) {
+		this.validationHintResolver = validationHintResolver;
+	}
+
+	/**
 	 * Invoke the validators available by convention.
 	 */
 	public void validate() {
 		if (this.validator != null) {
-			invokeValidatorDefaultValidateMethod(model, this.validator);
+			invokeValidatorDefaultValidateMethod(this.validator);
 		}
 		invokeModelValidationMethod(model);
 		Object modelValidator = getModelValidator();
 		if (modelValidator != null) {
-			invokeModelValidator(model, modelValidator);
+			invokeModelValidator(modelValidator);
 		}
 	}
 
@@ -191,12 +213,12 @@ public class ValidationHelper {
 		return null;
 	}
 
-	private void invokeModelValidator(Object model, Object validator) {
-		invokeValidatorValidateMethodForCurrentState(model, validator);
-		invokeValidatorDefaultValidateMethod(model, validator);
+	private void invokeModelValidator(Object validator) {
+		invokeValidatorValidateMethodForCurrentState(validator);
+		invokeValidatorDefaultValidateMethod(validator);
 	}
 
-	private boolean invokeValidatorValidateMethodForCurrentState(Object model, Object validator) {
+	private boolean invokeValidatorValidateMethodForCurrentState(Object validator) {
 		String methodName = "validate" + StringUtils.capitalize(requestContext.getCurrentState().getId());
 		// preferred
 		Method validateMethod = findValidationMethod(model, validator, methodName, ValidationContext.class);
@@ -233,7 +255,7 @@ public class ValidationHelper {
 		return false;
 	}
 
-	private boolean invokeValidatorDefaultValidateMethod(Object model, Object validator) {
+	private boolean invokeValidatorDefaultValidateMethod(Object validator) {
 		if (validator instanceof Validator) {
 			// Spring Framework Validator type
 			Validator springValidator = (Validator) validator;
@@ -243,7 +265,16 @@ public class ValidationHelper {
 			if (springValidator.supports(model.getClass())) {
 				MessageContextErrors errors = new MessageContextErrors(requestContext.getMessageContext(), modelName,
 						model, expressionParser, messageCodesResolver, mappingResults);
-				springValidator.validate(model, errors);
+
+				if (springValidator instanceof SmartValidator) {
+					String flowId = requestContext.getActiveFlow().getId();
+					String stateId = requestContext.getCurrentState().getId();
+					Object[] hints = validationHintResolver.resolveValidationHints(model, flowId , stateId, validationHints);
+					((SmartValidator) springValidator).validate(model, errors, hints);
+				}
+				else {
+					springValidator.validate(model, errors);
+				}
 			} else {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Spring Validator '" + ClassUtils.getShortName(validator.getClass())
@@ -295,4 +326,5 @@ public class ValidationHelper {
 		}
 		return null;
 	}
+
 }

--- a/spring-webflow/src/main/java/org/springframework/webflow/validation/ValidationHintResolver.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/validation/ValidationHintResolver.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2008-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.webflow.validation;
+
+import org.springframework.webflow.execution.FlowExecutionException;
+
+/**
+ * A strategy for resolving String-based hints to Objects such as validation
+ * groups against a JSR-303 provider.
+ *
+ * @author Rossen Stoyanchev
+ * @since 2.4
+ */
+public interface ValidationHintResolver {
+
+	/**
+	 * Resolve the given String hints. Implementations may raise a
+	 * {@link FlowExecutionException} if a hint cannot be resolved.
+	 *
+	 * @param model the model object that will be validated using the hints
+	 * @param flowId the current flow id
+	 * @param stateId the current state id
+	 * @param hints the hints to resolve
+	 *
+	 * @return an array of resolved hints
+	 */
+	Object[] resolveValidationHints(Object model, String flowId, String stateId, String[] hints);
+
+}

--- a/spring-webflow/src/main/resources/META-INF/spring.schemas
+++ b/spring-webflow/src/main/resources/META-INF/spring.schemas
@@ -1,3 +1,4 @@
 http\://www.springframework.org/schema/webflow-config/spring-webflow-config-2.0.xsd=org/springframework/webflow/config/spring-webflow-config-2.0.xsd
 http\://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd=org/springframework/webflow/config/spring-webflow-config-2.3.xsd
-http\://www.springframework.org/schema/webflow-config/spring-webflow-config.xsd=org/springframework/webflow/config/spring-webflow-config-2.3.xsd
+http\://www.springframework.org/schema/webflow-config/spring-webflow-config-2.4.xsd=org/springframework/webflow/config/spring-webflow-config-2.4.xsd
+http\://www.springframework.org/schema/webflow-config/spring-webflow-config.xsd=org/springframework/webflow/config/spring-webflow-config-2.4.xsd

--- a/spring-webflow/src/main/resources/org/springframework/webflow/engine/model/builder/xml/spring-webflow-2.4.xsd
+++ b/spring-webflow/src/main/resources/org/springframework/webflow/engine/model/builder/xml/spring-webflow-2.4.xsd
@@ -527,6 +527,19 @@ The model object this view is bound to.  Typically used as the source of form fi
 									</xsd:documentation>
 								</xsd:annotation>
 							</xsd:attribute>
+							<xsd:attribute name="validation-hints" type="expression">
+								<xsd:annotation>
+									<xsd:documentation>
+										<![CDATA[
+A comma-separated list of validation hints such as validation groups against a JSR-303 provider.
+Each hint is used to find an inner Class either in the Class of the model or in one of its super classes.
+For example if org.example.MyModel contains an inner type State1, then State1 can be used as a hint.
+Hints can be also be fully qualified class names.
+The entire string with validatin hints is first evaluated as an expression.
+]]>
+									</xsd:documentation>
+								</xsd:annotation>
+							</xsd:attribute>
 						</xsd:complexType>
 					</xsd:element>
 					<xsd:element name="decision-state">

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ViewStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ViewStateModelTests.java
@@ -59,6 +59,7 @@ public class ViewStateModelTests extends TestCase {
 		parent.setRedirect("true");
 		parent.setPopup("true");
 		parent.setModel("fooModel");
+		parent.setValidationHints("foo");
 		parent.setView("fooView");
 
 		LinkedList<TransitionModel> transitions = new LinkedList<TransitionModel>();
@@ -89,6 +90,7 @@ public class ViewStateModelTests extends TestCase {
 		assertEquals("true", child.getRedirect());
 		assertEquals("true", child.getPopup());
 		assertEquals("fooModel", child.getModel());
+		assertEquals("foo", child.getValidationHints());
 		assertEquals("fooView", child.getView());
 		assertEquals("bar", child.getAttributes().get(0).getValue());
 		assertEquals("foo", child.getBinder().getBindings().get(0).getProperty());

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolverTests.java
@@ -8,6 +8,13 @@ public class WebFlowEntityResolverTests extends TestCase {
 
 	private static final String PUBLIC_ID = "http://www.springframework.org/schema/webflow";
 
+	public void testResolve24() throws Exception {
+		WebFlowEntityResolver resolver = new WebFlowEntityResolver();
+		InputSource source = resolver.resolveEntity(PUBLIC_ID,
+				"http://www.springframework.org/schema/webflow/spring-webflow-2.4.xsd");
+		assertNotNull(source);
+	}
+
 	public void testResolve20() throws Exception {
 		WebFlowEntityResolver resolver = new WebFlowEntityResolver();
 		InputSource source = resolver.resolveEntity(PUBLIC_ID,

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilderTests.java
@@ -146,6 +146,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		FlowModel flow = builder.getFlowModel();
 		ViewStateModel model = (ViewStateModel) flow.getStates().get(0);
 		assertEquals("formObject", model.getModel());
+		assertEquals("foo,bar", model.getValidationHints());
 		assertEquals("objectProperty", model.getBinder().getBindings().get(0).getProperty());
 		assertEquals("customConverter", model.getBinder().getBindings().get(0).getConverter());
 	}

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/flow-viewstate-model-binding.xml
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/flow-viewstate-model-binding.xml
@@ -1,8 +1,8 @@
 <flow xmlns="http://www.springframework.org/schema/webflow"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.springframework.org/schema/webflow http://www.springframework.org/schema/webflow/spring-webflow-2.0.xsd">
+      xsi:schemaLocation="http://www.springframework.org/schema/webflow http://www.springframework.org/schema/webflow/spring-webflow-2.4.xsd">
 
-	<view-state id="form" model="formObject">
+	<view-state id="form" model="formObject" validation-hints="foo,bar">
 		<binder>
 			<binding property="objectProperty" converter="customConverter" required="true" />	
 		</binder>

--- a/spring-webflow/src/test/java/org/springframework/webflow/validation/ValidationHelperTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/validation/ValidationHelperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2008-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.binding.validation.ValidationContext;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.validation.DefaultMessageCodesResolver;
 import org.springframework.validation.Errors;
-import org.springframework.validation.Validator;
+import org.springframework.validation.SmartValidator;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.StubViewFactory;
 import org.springframework.webflow.engine.ViewState;
@@ -39,10 +39,14 @@ public class ValidationHelperTests extends TestCase {
 
 	private String modelName;
 
+	private DefaultMessageCodesResolver codesResolver;
+
+
 	protected void setUp() throws Exception {
 		requestContext = new MockRequestControlContext();
 		eventId = "userEvent";
 		modelName = "model";
+		codesResolver = new DefaultMessageCodesResolver();
 	}
 
 	public void testValidateWithMessageContext() {
@@ -58,7 +62,7 @@ public class ValidationHelperTests extends TestCase {
 	public void testValidateWithValidationContext() {
 		Object model = new StubModelValidationContext();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		helper.validate();
 		MessageContext messages = requestContext.getMessageContext();
 		assertEquals(1, messages.getAllMessages().length);
@@ -70,7 +74,7 @@ public class ValidationHelperTests extends TestCase {
 		applicationContext.registerSingleton("modelValidator", StubModelMessageContext.class);
 		((Flow) requestContext.getActiveFlow()).setApplicationContext(applicationContext);
 		ValidationHelper helper = new ValidationHelper(new Object(), requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		helper.validate();
 		MessageContext messages = requestContext.getMessageContext();
 		assertEquals(1, messages.getAllMessages().length);
@@ -82,7 +86,7 @@ public class ValidationHelperTests extends TestCase {
 		applicationContext.registerSingleton("modelValidator", StubModelValidationContext.class);
 		((Flow) requestContext.getActiveFlow()).setApplicationContext(applicationContext);
 		ValidationHelper helper = new ValidationHelper(new Object(), requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		helper.validate();
 		MessageContext messages = requestContext.getMessageContext();
 		assertEquals(1, messages.getAllMessages().length);
@@ -94,7 +98,7 @@ public class ValidationHelperTests extends TestCase {
 		applicationContext.registerSingleton("modelValidator", StubModelErrors.class);
 		((Flow) requestContext.getActiveFlow()).setApplicationContext(applicationContext);
 		ValidationHelper helper = new ValidationHelper(new Object(), requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		helper.validate();
 		MessageContext messages = requestContext.getMessageContext();
 		assertEquals(1, messages.getAllMessages().length);
@@ -106,7 +110,7 @@ public class ValidationHelperTests extends TestCase {
 		applicationContext.registerSingleton("modelValidator", StubModelErrorsOverridden.class);
 		((Flow) requestContext.getActiveFlow()).setApplicationContext(applicationContext);
 		ValidationHelper helper = new ValidationHelper(new Object(), requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		helper.validate();
 		MessageContext messages = requestContext.getMessageContext();
 		assertEquals(1, messages.getAllMessages().length);
@@ -116,7 +120,7 @@ public class ValidationHelperTests extends TestCase {
 	public void testStateAndFallbackModelValidationMethodInvoked() {
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -127,7 +131,7 @@ public class ValidationHelperTests extends TestCase {
 	public void testFallbackModelValidationMethodInvoked() {
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -138,7 +142,7 @@ public class ValidationHelperTests extends TestCase {
 	public void testStateAndFallbackErrorsModelValidationMethodInvoked() {
 		ErrorsModel model = new ErrorsModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -149,7 +153,7 @@ public class ValidationHelperTests extends TestCase {
 	public void testFallbackModelErrorsValidationMethodInvoked() {
 		ErrorsModel model = new ErrorsModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -165,7 +169,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -181,7 +185,7 @@ public class ValidationHelperTests extends TestCase {
 
 		ExtendedModel model = new ExtendedModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -197,7 +201,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -213,7 +217,7 @@ public class ValidationHelperTests extends TestCase {
 
 		ExtendedModel model = new ExtendedModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -229,7 +233,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -245,7 +249,7 @@ public class ValidationHelperTests extends TestCase {
 
 		ExtendedModel model = new ExtendedModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -261,7 +265,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -277,7 +281,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -293,7 +297,7 @@ public class ValidationHelperTests extends TestCase {
 
 		ExtendedModel model = new ExtendedModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -309,7 +313,7 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
@@ -325,13 +329,62 @@ public class ValidationHelperTests extends TestCase {
 
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
-				new DefaultMessageCodesResolver(), null);
+				this.codesResolver, null);
 		ViewState state1 = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		requestContext.setCurrentState(state1);
 		helper.validate();
 		assertFalse(validator.state1Invoked);
 		assertTrue(validator.fallbackInvoked);
 	}
+
+	public void testSmartValidatorWithStateIdHint() {
+		LegacyModelValidator validator = new LegacyModelValidator();
+		ExtendedModel model = new ExtendedModel();
+		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null, codesResolver, null);
+		helper.setValidator(validator);
+
+		ViewState state = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
+		requestContext.setCurrentState(state);
+
+		helper.validate();
+
+		assertTrue(validator.fallbackInvoked);
+		assertTrue(validator.hints.length > 0);
+		assertEquals(ExtendedModel.State2.class, validator.hints[0]);
+	}
+
+	public void testSmartValidatorWithStateIdHintInParentClass() {
+		LegacyModelValidator validator = new LegacyModelValidator();
+		ExtendedModel model = new ExtendedModel();
+		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null, codesResolver, null);
+		helper.setValidator(validator);
+
+		ViewState state = new ViewState(requestContext.getRootFlow(), "state1", new StubViewFactory());
+		requestContext.setCurrentState(state);
+
+		helper.validate();
+
+		assertTrue(validator.fallbackInvoked);
+		assertTrue(validator.hints.length > 0);
+		assertEquals(Model.State1.class, validator.hints[0]);
+	}
+
+
+	public void testSmartValidatorWithoutHintForStateId() {
+		LegacyModelValidator validator = new LegacyModelValidator();
+		ExtendedModel model = new ExtendedModel();
+		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null, codesResolver, null);
+		helper.setValidator(validator);
+
+		ViewState state = new ViewState(requestContext.getRootFlow(), "state99", new StubViewFactory());
+		requestContext.setCurrentState(state);
+
+		helper.validate();
+
+		assertTrue(validator.fallbackInvoked);
+		assertEquals(0, validator.hints.length);
+	}
+
 
 	public static class Model {
 		private boolean state1Invoked;
@@ -344,9 +397,13 @@ public class ValidationHelperTests extends TestCase {
 		public void validate(ValidationContext context) {
 			fallbackInvoked = true;
 		}
+
+		private static class State1 {}
 	}
 
 	public static class ExtendedModel extends Model {
+
+		private static class State2 {}
 	}
 
 	public static class ErrorsModel {
@@ -362,9 +419,10 @@ public class ValidationHelperTests extends TestCase {
 		}
 	}
 
-	public static class LegacyModelValidator implements Validator {
+	public static class LegacyModelValidator implements SmartValidator {
 		private boolean state1Invoked;
 		private boolean fallbackInvoked;
+		private Object[] hints;
 
 		public void validateState1(Model model, Errors errors) {
 			state1Invoked = true;
@@ -372,6 +430,11 @@ public class ValidationHelperTests extends TestCase {
 
 		public void validate(Object object, Errors errors) {
 			fallbackInvoked = true;
+		}
+
+		public void validate(Object object, Errors errors, Object... hints) {
+			fallbackInvoked = true;
+			this.hints = hints;
 		}
 
 		public boolean supports(Class<?> clazz) {


### PR DESCRIPTION
This change makes it possible to use validation hints in conjunction
with declarative, JSR-303 validation. Such hints may be defined in an
attribute of the view state where the view state id itself is also
interpeted as a hint.

Each hint is converted to a Class either by searching for a matching
inner Class within the model or any of its super classes. A hint may
also be a fully qualified class name.

Issue: SWF-1453
