### PR TITLE
Support for multi-part file uploads

### DIFF
--- a/spring-faces/src/main/java/org/springframework/faces/webflow/JsfView.java
+++ b/spring-faces/src/main/java/org/springframework/faces/webflow/JsfView.java
@@ -30,7 +30,7 @@ import org.springframework.webflow.execution.View;
 
 /**
  * JSF-specific {@link View} implementation.
- * 
+ *
  * @author Jeremy Grelle
  * @author Phillip Webb
  */
@@ -47,7 +47,7 @@ public class JsfView implements View {
 	private final RequestContext requestContext;
 
 	private String viewId;
-	
+
 	/**
 	 * Creates a new JSF view.
 	 * @param viewRoot the view root
@@ -97,7 +97,11 @@ public class JsfView implements View {
 	}
 
 	public boolean userEventQueued() {
-		return this.requestContext.getRequestParameters().contains("javax.faces.ViewState");
+		FacesContext facesContext = FlowFacesContext.getCurrentInstance();
+		if(facesContext != null) {
+			facesContext.getExternalContext().getRequestParameterMap().containsKey("javax.faces.ViewState");
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Change JsfView.userEventQueued() to check for 'javax.faces.ViewState'
via the FacesContext rather than the RequestContext. This allows
potential multi-part request submissions to be processed by JSF rather
than Spring.

Issue: 
