### PR TITLE
Fix for SWF-1619

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ configure(subprojects) { subproject ->
 	repositories {
 		maven { url "http://repo.springsource.org/libs-release" }
 		maven { url "http://repo.springsource.org/libs-snapshot" }
+		mavenCentral()
 	}
 
 	jar {
@@ -52,7 +53,10 @@ configure(subprojects.findAll {it.name != "spring-js-resources"}) { subproject -
 	dependencies {
 		testCompile("junit:junit-dep:4.10")
 		testCompile("org.hamcrest:hamcrest-all:1.3")
-		testCompile("org.easymock:easymock:3.1")
+		testCompile("org.objenesis:objenesis:2.1")
+		testCompile("org.easymock:easymock:3.1") {
+		       exclude module: 'objenesis'
+		}
 	}
 
 	subproject.ext {


### PR DESCRIPTION
The fix for the main issue is done by excluding the objenesis reference in easymock and include the objenesis release from maven central.

maven central needs to be referenced as a reposiroty because otherwise the optional hibernate 3.x dependency will fail due to a protected reference to asm:asm:3.1
