### PR TITLE
Add the Spring IO plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ buildscript {
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.5")
+		classpath("org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE")
 		classpath("org.springframework.build.gradle:docbook-reference-plugin:0.2.8")
 		classpath("me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1")
 	}
@@ -52,6 +53,18 @@ configure(subprojects.findAll {it.name != "spring-build-src"}) { subproject ->
 configure(subprojects.findAll {
 		it.name != "spring-build-src" && it.name != "spring-js-resources"}) { subproject ->
 
+	if (project.hasProperty('platformVersion')) {
+		apply plugin: 'spring-io'
+
+		repositories {
+			maven { url "https://repo.spring.io/libs-snapshot" }
+		}
+
+		dependencies {
+			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+		}
+	}
+
 	dependencies {
 		testCompile("junit:junit-dep:4.10")
 		testCompile("org.hamcrest:hamcrest-all:1.3")
@@ -65,9 +78,13 @@ configure(subprojects.findAll {
 	  log4jVersion = "1.2.17"
 	}
 
-	test {
-	  systemProperty("java.awt.headless", "true")
-	  include "**/*Tests.class"
+	tasks.withType(Test).all {
+		systemProperty("java.awt.headless", "true")
+		include "**/*Tests.class"
+
+		if (name ==~ /springIo.*/) {
+			exclude '**/tiles2/**'
+		}
 	}
 
 	javadoc {


### PR DESCRIPTION
Configure the Spring IO plugin such that it's only applied when the build is run with `-PplatformVersion=<version>`. This `platformVersion` property is used to determine the version of the Platform that will
be used when running the `springIoCheck` task. The plugin can be used by running a build as follows:

```
./gradlew clean springIoCheck -PplatformVersion=1.0.0.BUILD-SNAPSHOT -PJDK7_HOME=… -PJDK8_HOME=…
```

This will test the project on JDK 7 and JDK 8 using the dependencies defined in the latest snapshot of Spring IO Platform 1.0.0.

The Spring IO test tasks have been configured to exclude the Tiles 2 tests as Spring IO uses Tiles 3.
