### PR TITLE
Move state saving to getUserEventState()

### DIFF
--- a/spring-faces/src/main/java/org/springframework/faces/webflow/JsfView.java
+++ b/spring-faces/src/main/java/org/springframework/faces/webflow/JsfView.java
@@ -106,10 +106,6 @@ public class JsfView implements View {
 	 */
 	public void processUserEvent() {
 		FacesContext facesContext = FlowFacesContext.getCurrentInstance();
-
-		// Ensure serialized view state is always updated even if JSF didn't call StateManager.writeState(). SWF-1577
-		saveState();
-
 		// Must respect these flags in case user set them during RESTORE_VIEW phase
 		if (!facesContext.getRenderResponse() && !facesContext.getResponseComplete()) {
 			this.facesLifecycle.execute(facesContext);
@@ -129,6 +125,10 @@ public class JsfView implements View {
 	public Serializable getUserEventState() {
 		// Set the temporary UIViewRoot state so that it will be available across the redirect (see comments in render()
 		// method)
+
+		// Ensure serialized view state is always updated even if JSF didn't call StateManager.writeState(). SWF-1577
+		saveState();
+
 		return new ViewRootHolder(getViewRoot());
 	}
 


### PR DESCRIPTION
Update JsfView so that state saving no longer occurs during
processUserEvent(). This is required to ensure that Mojarra's
StateContext.release(...) method is not called too early.

Prior to Mojarra 2.1.16 multiple calls to saveView had no side effects,
but the fix to  changed this behavior.

In order to retain the fix for  the saveState() method is now
called from getUserEventState(). This should ensure that the
StateContext$AddRemoveListerner is still removed, even when WebFlow
bypasses the usual state saving for certain flow redirects.

Issue: 
