### PR TITLE
Use the latest version of the Spring IO Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
-		classpath("org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE")
+		classpath("io.spring.gradle:spring-io-plugin:0.0.4.RELEASE")
 		classpath("io.spring.gradle:docbook-reference-plugin:0.3.1")
 		classpath("me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1")
 	}
@@ -59,8 +59,12 @@ configure(subprojects.findAll {
 			maven { url "https://repo.spring.io/libs-snapshot" }
 		}
 
-		dependencies {
-			springIoVersions "io.spring.platform:platform-versions:${platformVersion}@properties"
+		dependencyManagement {
+			springIoTestRuntime {
+				imports {
+					mavenBom "io.spring.platform:platform-bom:${platformVersion}"
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This change is necessary to allow Spring IO Platform 2.0 to remove the platform-versions properties file that was deprecated in 1.1. To allow Spring Web Flow's Platform compliance to be verified as part of Spring IO Platform 2.0's build and release process, I'd like this to be included in Spring Web Flow 2.4.x which is the version that's currently in Spring IO Platform 2.0. If you have any questions, please let me know.