### PR TITLE
Reinstate logic that applies publish-maven.gradle to subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ allprojects {
 
 subprojects { subproject ->
 
+	apply from: "${rootProject.projectDir}/publish-maven.gradle"
+
 	sourceCompatibility=1.8
 	targetCompatibility=1.8
 


### PR DESCRIPTION
Without applying publish-maven.gradle no Maven poms are generated.