### PR TITLE
Override dependency management plugin for Gradle 4.x compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
 		classpath("io.spring.gradle:spring-io-plugin:0.0.5.RELEASE")
+		classpath("io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE")
 		classpath("io.spring.gradle:docbook-reference-plugin:0.3.1")
 		classpath("me.champeau.gradle:gradle-javadoc-hotfix-plugin:0.1")
 	}


### PR DESCRIPTION
This fixes a failure with the Spring IO compatibility checks that was due to an incompatibility between Gradle 4 and the version of the dependency management plugin that the Spring IO plugin uses by default.