### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url "http://repo.spring.io/plugins-release" }
+		maven { url "https://repo.spring.io/plugins-release" }
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
@@ -30,8 +30,8 @@ subprojects { subproject ->
 	sourceSets.test.resources.srcDirs = ["src/main/java", "src/test/resources", "src/test/java"]
 
 	repositories {
-		maven { url "http://repo.spring.io/libs-release" }
-		maven { url "http://repo.spring.io/libs-snapshot" }
+		maven { url "https://repo.spring.io/libs-release" }
+		maven { url "https://repo.spring.io/libs-snapshot" }
 	}
 
 	jar {

--- a/ide.gradle
+++ b/ide.gradle
@@ -11,7 +11,7 @@ eclipse.jdt {
 }
 
 // Replace classpath entries with project dependencies (GRADLE-1116)
-// http://issues.gradle.org/browse/GRADLE-1116
+// https://issues.gradle.org/browse/GRADLE-1116
 eclipse.classpath.file.whenMerged { classpath ->
 	def regexp = /.*?\/([^\/]+)\/build\/[^\/]+\/(?:main|test)/ // only match those that end in main or test (avoids removing necessary entries like build/classes/jaxb)
 	def projectOutputDependencies = classpath.entries.findAll { entry -> entry.path =~ regexp }

--- a/import-into-eclipse.sh
+++ b/import-into-eclipse.sh
@@ -14,7 +14,7 @@ been tested against STS $STS_TEST_VERSION), but at the minimum you will
 need Eclipse + AJDT.
 
 If you need to download and install STS, please do that now by
-visiting http://springsource.org/downloads/sts
+visiting https://spring.io/projectss/sts
 
 Otherwise, press enter and we'll begin.
 EOM

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -25,12 +25,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/spring-projects/spring-webflow"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-webflow"
+				url = "https://projects.spring.io/spring-webflow"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://springsource.org/downloads/sts (302) migrated to:  
  https://spring.io/projectss/sts ([https](https://springsource.org/downloads/sts) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://issues.gradle.org/browse/GRADLE-1116 migrated to:  
  https://issues.gradle.org/browse/GRADLE-1116 ([https](https://issues.gradle.org/browse/GRADLE-1116) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://projects.spring.io/spring-webflow migrated to:  
  https://projects.spring.io/spring-webflow ([https](https://projects.spring.io/spring-webflow) result 301).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/libs-snapshot migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).
* http://repo.spring.io/plugins-release migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).