### PR TITLE
Upgrade to JUnit 4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,7 @@ project("spring-webflow") {
 		optional("org.apache.tiles:tiles-extras:$tiles3Version") {
 			exclude group: "org.springframework", module: "spring-web"
 		}
-		provided("junit:junit:3.8.2")
+		provided("junit:junit:4.12")
 		testCompile("org.springframework:spring-aop:$springVersion")
 		testCompile("org.springframework:spring-jdbc:$springVersion")
 		testCompile("org.springframework:spring-test:$springVersion")

--- a/spring-binding/src/test/java/org/springframework/binding/collection/MapAccessorTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/collection/MapAccessorTests.java
@@ -1,14 +1,18 @@
 package org.springframework.binding.collection;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
-public class MapAccessorTests extends TestCase {
+public class MapAccessorTests {
 	private MapAccessor<String, Object> accessor;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() {
 		Map<String, Object> map = new HashMap<>();
 		map.put("string", "hello");
 		map.put("integer", 9);
@@ -16,6 +20,7 @@ public class MapAccessorTests extends TestCase {
 		this.accessor = new MapAccessor<>(map);
 	}
 
+	@Test
 	public void testAccessNullAttribute() {
 		assertEquals(null, accessor.get("null"));
 		assertEquals(null, accessor.get("null", "something else"));
@@ -28,16 +33,19 @@ public class MapAccessorTests extends TestCase {
 		assertEquals(null, accessor.getRequiredCollection("null"));
 	}
 
+	@Test
 	public void testGetString() {
 		assertEquals("hello", accessor.getString("string"));
 		assertEquals("hello", accessor.getRequiredString("string"));
 	}
 
+	@Test
 	public void testGetInteger() {
 		assertEquals(new Integer(9), accessor.getInteger("integer"));
 		assertEquals(new Integer(9), accessor.getRequiredInteger("integer"));
 	}
 
+	@Test
 	public void testGetRequiredMissingKey() {
 		try {
 			accessor.getRequired("bogus");

--- a/spring-binding/src/test/java/org/springframework/binding/collection/SharedMapDecoratorTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/collection/SharedMapDecoratorTests.java
@@ -15,21 +15,28 @@
  */
 package org.springframework.binding.collection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link org.springframework.binding.collection.SharedMapDecorator}.
  */
-public class SharedMapDecoratorTests extends TestCase {
+public class SharedMapDecoratorTests {
 
 	private SharedMapDecorator<String, String> map = new SharedMapDecorator<>(
 			new HashMap<>());
 
+	@Test
 	public void testGetPutRemove() {
 		assertTrue(map.size() == 0);
 		assertTrue(map.isEmpty());
@@ -47,6 +54,7 @@ public class SharedMapDecoratorTests extends TestCase {
 		assertNull(map.get("foo"));
 	}
 
+	@Test
 	public void testPutAll() {
 		Map<String, String> all = new HashMap<>();
 		all.put("foo", "bar");
@@ -55,6 +63,7 @@ public class SharedMapDecoratorTests extends TestCase {
 		assertTrue(map.size() == 2);
 	}
 
+	@Test
 	public void testEntrySet() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");
@@ -62,6 +71,7 @@ public class SharedMapDecoratorTests extends TestCase {
 		assertTrue(entrySet.size() == 2);
 	}
 
+	@Test
 	public void testKeySet() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");
@@ -69,6 +79,7 @@ public class SharedMapDecoratorTests extends TestCase {
 		assertTrue(keySet.size() == 2);
 	}
 
+	@Test
 	public void testValues() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");

--- a/spring-binding/src/test/java/org/springframework/binding/collection/StringKeyedMapAdapterTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/collection/StringKeyedMapAdapterTests.java
@@ -15,18 +15,24 @@
  */
 package org.springframework.binding.collection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link org.springframework.binding.collection.StringKeyedMapAdapter}.
  */
-public class StringKeyedMapAdapterTests extends TestCase {
+public class StringKeyedMapAdapterTests {
 
 	private Map<String, String> contents = new HashMap<>();
 
@@ -49,6 +55,7 @@ public class StringKeyedMapAdapterTests extends TestCase {
 		}
 	};
 
+	@Test
 	public void testGetPutRemove() {
 		assertTrue(map.size() == 0);
 		assertTrue(map.isEmpty());
@@ -66,6 +73,7 @@ public class StringKeyedMapAdapterTests extends TestCase {
 		assertNull(map.get("foo"));
 	}
 
+	@Test
 	public void testPutAll() {
 		Map<String, String> all = new HashMap<>();
 		all.put("foo", "bar");
@@ -74,6 +82,7 @@ public class StringKeyedMapAdapterTests extends TestCase {
 		assertTrue(map.size() == 2);
 	}
 
+	@Test
 	public void testEntrySet() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");
@@ -81,6 +90,7 @@ public class StringKeyedMapAdapterTests extends TestCase {
 		assertTrue(entrySet.size() == 2);
 	}
 
+	@Test
 	public void testKeySet() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");
@@ -88,6 +98,7 @@ public class StringKeyedMapAdapterTests extends TestCase {
 		assertTrue(keySet.size() == 2);
 	}
 
+	@Test
 	public void testValues() {
 		map.put("foo", "bar");
 		map.put("bar", "baz");

--- a/spring-binding/src/test/java/org/springframework/binding/convert/service/DefaultConversionServiceTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/convert/service/DefaultConversionServiceTests.java
@@ -15,6 +15,11 @@
  */
 package org.springframework.binding.convert.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.security.Principal;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -27,8 +32,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionException;
 import org.springframework.binding.convert.ConversionExecutionException;
 import org.springframework.binding.convert.ConversionExecutor;
@@ -45,14 +49,16 @@ import org.springframework.binding.format.DefaultNumberFormatFactory;
  * 
  * @author Keith Donald
  */
-public class DefaultConversionServiceTests extends TestCase {
+public class DefaultConversionServiceTests {
 
+	@Test
 	public void testConvertCompatibleTypes() {
 		DefaultConversionService service = new DefaultConversionService();
 		List<Object> lst = new ArrayList<>();
 		assertSame(lst, service.getConversionExecutor(ArrayList.class, List.class).execute(lst));
 	}
 
+	@Test
 	public void testOverrideConverter() {
 		Converter customConverter = new StringToBoolean("ja", "nee");
 		DefaultConversionService service = new DefaultConversionService();
@@ -69,6 +75,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertTrue(((Boolean) executor.execute("ja")));
 	}
 
+	@Test
 	public void testTargetClassNotSupported() {
 		DefaultConversionService service = new DefaultConversionService();
 		try {
@@ -78,6 +85,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testValidConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String.class, Integer.class);
@@ -89,6 +97,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", threeString);
 	}
 
+	@Test
 	public void testRegisterConverter() {
 		GenericConversionService service = new GenericConversionService();
 		FormattedStringToNumber converter = new FormattedStringToNumber();
@@ -104,6 +113,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3,000", string);
 	}
 
+	@Test
 	public void testRegisterCustomConverter() {
 		DefaultConversionService service = new DefaultConversionService();
 		FormattedStringToNumber converter = new FormattedStringToNumber();
@@ -119,6 +129,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3,000", string);
 	}
 
+	@Test
 	public void testRegisterCustomConverterForSameType() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("trimmer", new Trimmer());
@@ -126,6 +137,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("a string", executor.execute("a string   "));
 	}
 
+	@Test
 	public void testRegisterCustomConverterForSameTypeNotCompatibleSource() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("trimmer", new Trimmer());
@@ -136,6 +148,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterCustomConverterForSameTypeNotCompatibleTarget() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("trimmer", new Trimmer());
@@ -146,6 +159,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterCustomConverterReverseComparsion() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -157,6 +171,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}));
 	}
 
+	@Test
 	public void testRegisterCustomConverterReverseNotCompatibleSource() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -167,6 +182,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterCustomConverterArrayToArray() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -176,6 +192,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", p[1].getName());
 	}
 
+	@Test
 	public void testRegisterCustomConverterArrayToArrayReverse() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -195,6 +212,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", p[1]);
 	}
 
+	@Test
 	public void testRegisterCustomConverterArrayToArrayBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -205,6 +223,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterArrayToList() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -215,6 +234,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", (list.get(1)).getName());
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterArrayToListReverse() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -227,6 +247,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", p.get(1));
 	}
 
+	@Test
 	public void testRegisterCustomConverterArrayToListBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -238,6 +259,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterCustomConverterListToArray() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -250,6 +272,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", p[1].getName());
 	}
 
+	@Test
 	public void testRegisterCustomConverterListToArrayReverse() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -264,6 +287,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", p[1]);
 	}
 
+	@Test
 	public void testRegisterCustomConverterListToArrayBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -275,6 +299,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterCustomConverterObjectToArray() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -283,6 +308,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy1", p[0].getName());
 	}
 
+	@Test
 	public void testRegisterCustomConverterObjectToArrayReverse() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -292,6 +318,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy1", p[0]);
 	}
 
+	@Test
 	public void testRegisterCustomConverterObjectToArrayBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -303,6 +330,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterObjectToList() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -312,6 +340,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy1", list.get(0).getName());
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterCsvStringToList() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -322,6 +351,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", list.get(1).getName());
 	}
 
+	@Test
 	public void testRegisterCustomConverterObjectToListBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -334,6 +364,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterObjectToListReverse() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -344,6 +375,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy1", list.get(0));
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterListToList() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -357,6 +389,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", list.get(1).getName());
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testRegisterCustomConverterListToListReverse() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -372,6 +405,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("princy2", list.get(1));
 	}
 
+	@Test
 	public void testRegisterCustomConverterListToListBogus() {
 		DefaultConversionService service = new DefaultConversionService();
 		service.addConverter("princy", new CustomTwoWayConverter());
@@ -386,6 +420,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testConversionPrimitive() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String.class, int.class);
@@ -393,6 +428,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals(new Integer(3), three);
 	}
 
+	@Test
 	public void testArrayToArrayConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String[].class, Integer[].class);
@@ -402,6 +438,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals(new Integer(3), result[2]);
 	}
 
+	@Test
 	public void testArrayToArrayPrimitiveConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String[].class, int[].class);
@@ -411,6 +448,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals(3, result[2]);
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testArrayToListConversion() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -421,6 +459,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result.get(2));
 	}
 
+	@Test
 	public void testListToArrayConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(Collection.class, String[].class);
@@ -434,6 +473,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result[2]);
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testSetToListConversion() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -448,6 +488,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result.get(2));
 	}
 
+	@Test
 	public void testListToArrayConversionWithComponentConversion() {
 		try {
 			DefaultConversionService service = new DefaultConversionService();
@@ -470,6 +511,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testArrayToLinkedListConversion() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -480,6 +522,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result.get(2));
 	}
 
+	@Test
 	public void testArrayAbstractListConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		try {
@@ -489,6 +532,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStringToArrayConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String.class, String[].class);
@@ -499,6 +543,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result[2]);
 	}
 
+	@Test
 	@SuppressWarnings("unchecked")
 	public void testStringToListConversion() {
 		DefaultConversionService service = new DefaultConversionService();
@@ -510,6 +555,7 @@ public class DefaultConversionServiceTests extends TestCase {
 		assertEquals("3", result.get(2));
 	}
 
+	@Test
 	public void testStringToArrayConversionWithElementConversion() {
 		DefaultConversionService service = new DefaultConversionService();
 		ConversionExecutor executor = service.getConversionExecutor(String.class, Integer[].class);

--- a/spring-binding/src/test/java/org/springframework/binding/convert/service/StaticConversionExecutorImplTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/convert/service/StaticConversionExecutorImplTests.java
@@ -15,26 +15,34 @@
  */
 package org.springframework.binding.convert.service;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Date;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionExecutionException;
 import org.springframework.binding.convert.converters.StringToDate;
 
-public class StaticConversionExecutorImplTests extends TestCase {
+public class StaticConversionExecutorImplTests {
 
 	private StaticConversionExecutor conversionExecutor;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StringToDate stringToDate = new StringToDate();
 		conversionExecutor = new StaticConversionExecutor(String.class, Date.class, stringToDate);
 	}
 
+	@Test
 	public void testTypeConversion() {
 		assertTrue(conversionExecutor.execute("2008-10-10").getClass().equals(Date.class));
 	}
 
+	@Test
 	public void testAssignmentCompatibleTypeConversion() {
 		java.sql.Date date = new java.sql.Date(123L);
 		try {
@@ -45,10 +53,12 @@ public class StaticConversionExecutorImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testConvertNull() {
 		assertNull(conversionExecutor.execute(null));
 	}
 
+	@Test
 	public void testIllegalType() {
 		try {
 			conversionExecutor.execute(new StringBuilder());

--- a/spring-binding/src/test/java/org/springframework/binding/expression/beanwrapper/BeanWrapperExpressionParserTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/expression/beanwrapper/BeanWrapperExpressionParserTests.java
@@ -15,8 +15,13 @@
  */
 package org.springframework.binding.expression.beanwrapper;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.binding.convert.converters.StringToDate;
 import org.springframework.binding.convert.service.GenericConversionService;
@@ -25,12 +30,13 @@ import org.springframework.binding.expression.ParserException;
 import org.springframework.binding.expression.ValueCoercionException;
 import org.springframework.binding.expression.support.FluentParserContext;
 
-public class BeanWrapperExpressionParserTests extends TestCase {
+public class BeanWrapperExpressionParserTests {
 
 	private BeanWrapperExpressionParser parser = new BeanWrapperExpressionParser();
 
 	private TestBean bean = new TestBean();
 
+	@Test
 	public void testParseSimple() {
 		String exp = "flag";
 		Expression e = parser.parseExpression(exp, null);
@@ -39,6 +45,7 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		assertFalse(b);
 	}
 
+	@Test
 	public void testParseSimpleAllowDelimited() {
 		parser.setAllowDelimitedEvalExpressions(true);
 		String exp = "${flag}";
@@ -48,6 +55,7 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		assertFalse(b);
 	}
 
+	@Test
 	public void testParseSimpleDelimitedNotAllowed() {
 		String exp = "${flag}";
 		try {
@@ -57,6 +65,7 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseTemplateSimpleLiteral() {
 		String exp = "flag";
 		Expression e = parser.parseExpression(exp, new FluentParserContext().template());
@@ -64,12 +73,14 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		assertEquals("flag", e.getValue(bean));
 	}
 
+	@Test
 	public void testParseTemplateEmpty() {
 		Expression e = parser.parseExpression("", new FluentParserContext().template());
 		assertNotNull(e);
 		assertEquals("", e.getValue(bean));
 	}
 
+	@Test
 	public void testParseTemplateComposite() {
 		String exp = "hello ${flag} ${flag} ${flag}";
 		Expression e = parser.parseExpression(exp, new FluentParserContext().template());
@@ -78,6 +89,7 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		assertEquals("hello false false false", str);
 	}
 
+	@Test
 	public void testTemplateEnclosedCompositeNotSupported() {
 		String exp = "${hello ${flag} ${flag} ${flag}}";
 		try {
@@ -87,18 +99,21 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetValueType() {
 		String exp = "flag";
 		Expression e = parser.parseExpression(exp, null);
 		assertEquals(boolean.class, e.getValueType(bean));
 	}
 
+	@Test
 	public void testGetValueTypeNullCollectionValue() {
 		String exp = "list[0]";
 		Expression e = parser.parseExpression(exp, null);
 		assertEquals(null, e.getValueType(bean));
 	}
 
+	@Test
 	public void testSetValueWithCoersion() {
 		GenericConversionService cs = (GenericConversionService) parser.getConversionService();
 		StringToDate converter = new StringToDate();
@@ -108,6 +123,7 @@ public class BeanWrapperExpressionParserTests extends TestCase {
 		e.setValue(bean, "2008-9-15");
 	}
 
+	@Test
 	public void testSetBogusValueWithCoersion() {
 		Expression e = parser.parseExpression("date", null);
 		try {

--- a/spring-binding/src/test/java/org/springframework/binding/expression/el/ELExpressionParserTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/expression/el/ELExpressionParserTests.java
@@ -1,5 +1,8 @@
 package org.springframework.binding.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.beans.FeatureDescriptor;
 import java.util.Iterator;
 
@@ -8,9 +11,9 @@ import javax.el.ELResolver;
 import javax.el.FunctionMapper;
 import javax.el.VariableMapper;
 
-import junit.framework.TestCase;
-
 import org.apache.el.ExpressionFactoryImpl;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.EvaluationException;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionVariable;
@@ -18,20 +21,23 @@ import org.springframework.binding.expression.ParserException;
 import org.springframework.binding.expression.ValueCoercionException;
 import org.springframework.binding.expression.support.FluentParserContext;
 
-public class ELExpressionParserTests extends TestCase {
+public class ELExpressionParserTests {
 
 	private ELExpressionParser parser = new ELExpressionParser(new ExpressionFactoryImpl());
 
+	@Before
 	public void setUp() {
 		parser.putContextFactory(TestBean.class, new TestELContextFactory());
 	}
 
+	@Test
 	public void testParseSimpleEvalExpressionNoParserContext() {
 		String expressionString = "3 + 4";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals(7L, exp.getValue(null));
 	}
 
+	@Test
 	public void testParseNullExpressionString() {
 		String expressionString = null;
 		try {
@@ -42,11 +48,13 @@ public class ELExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseNull() {
 		Expression exp = parser.parseExpression("null", null);
 		assertEquals(null, exp.getValue(null));
 	}
 
+	@Test
 	public void testParseEmptyExpressionString() {
 		String expressionString = "";
 		try {
@@ -57,6 +65,7 @@ public class ELExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseSimpleEvalExpressionNoEvalContextWithTypeCoersion() {
 		String expressionString = "3 + 4";
 		Expression exp = parser
@@ -64,24 +73,28 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals(7, exp.getValue(null));
 	}
 
+	@Test
 	public void testParseBeanEvalExpressionNoParserContext() {
 		String expressionString = "value";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("foo", exp.getValue(new TestBean()));
 	}
 
+	@Test
 	public void testParseEvalExpressionWithContextTypeCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().expectResult(Long.class));
 		assertEquals(2L, exp.getValue(new TestBean()));
 	}
 
+	@Test
 	public void testParseEvalExpressionWithContextCustomELVariableResolver() {
 		String expressionString = "specialProperty";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().evaluate(TestBean.class));
 		assertEquals("Custom resolver resolved this special property!", exp.getValue(new TestBean()));
 	}
 
+	@Test
 	public void testParseBeanEvalExpressionInvalidELVariable() {
 		try {
 			String expressionString = "bogus";
@@ -94,12 +107,14 @@ public class ELExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseLiteralExpression() {
 		String expressionString = "'value'";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("value", exp.getValue(null));
 	}
 
+	@Test
 	public void testParseTemplateExpression() {
 		String expressionString = "text text text #{value} text text text#{value}";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().template());
@@ -107,6 +122,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals("text text text foo text text textfoo", exp.getValue(target));
 	}
 
+	@Test
 	public void testParseTemplateExpressionWithVariables() {
 		String expressionString = "#{value}#{max}";
 		Expression exp = parser.parseExpression(expressionString,
@@ -115,6 +131,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals("foo2", exp.getValue(target));
 	}
 
+	@Test
 	public void testVariablesWithCoersion() {
 		Expression exp = parser.parseExpression("max", new FluentParserContext().variable(new ExpressionVariable("max",
 				"maximum", new FluentParserContext().expectResult(Long.class))));
@@ -122,6 +139,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals(2L, exp.getValue(target));
 	}
 
+	@Test
 	public void testTemplateNestedVariables() {
 		String expressionString = "#{value}#{max}";
 		Expression exp = parser.parseExpression(
@@ -140,12 +158,14 @@ public class ELExpressionParserTests extends TestCase {
 	// assertEquals(null, e.getValueType(target));
 	// }
 
+	@Test
 	public void testGetExpressionString() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("maximum", exp.getExpressionString());
 	}
 
+	@Test
 	public void testGetExpressionType() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -153,6 +173,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals(int.class, exp.getValueType(context));
 	}
 
+	@Test
 	public void testGetValueWithCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().expectResult(String.class));
@@ -160,6 +181,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals("2", exp.getValue(context));
 	}
 
+	@Test
 	public void testGetValueCoersionError() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString,
@@ -172,6 +194,7 @@ public class ELExpressionParserTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testSetValue() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -180,6 +203,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals(5, context.getMaximum());
 	}
 
+	@Test
 	public void testSetValueWithTypeCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -188,6 +212,7 @@ public class ELExpressionParserTests extends TestCase {
 		assertEquals(5, context.getMaximum());
 	}
 
+	@Test
 	public void testSetValueCoersionError() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);

--- a/spring-binding/src/test/java/org/springframework/binding/expression/el/MapAdaptableELResolverTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/expression/el/MapAdaptableELResolverTests.java
@@ -1,46 +1,55 @@
 package org.springframework.binding.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.el.ELContext;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.collection.MapAdaptable;
 
-public class MapAdaptableELResolverTests extends TestCase {
+public class MapAdaptableELResolverTests {
 
 	private ELContext context;
 
+	@Before
 	public void setUp() {
 		context = new DefaultELContext(new MapAdaptableELResolver(), null, null);
 	}
 
+	@Test
 	public void testGetType() {
 		Class<?> type = context.getELResolver().getType(context, new TestMapAdaptable(), "bar");
 		assertTrue(context.isPropertyResolved());
 		assertEquals(String.class, type);
 	}
 
+	@Test
 	public void testGetType_UnknownProperty() {
 		Class<?> type = context.getELResolver().getType(context, new TestMapAdaptable(), "foo");
 		assertTrue(context.isPropertyResolved());
 		assertEquals(null, type);
 	}
 
+	@Test
 	public void testGetValue() {
 		Object value = context.getELResolver().getValue(context, new TestMapAdaptable(), "bar");
 		assertTrue(context.isPropertyResolved());
 		assertEquals("bar", value);
 	}
 
+	@Test
 	public void testGetValue_UnknownProperty() {
 		Object value = context.getELResolver().getValue(context, new TestMapAdaptable(), "foo");
 		assertTrue(context.isPropertyResolved());
 		assertEquals(null, value);
 	}
 
+	@Test
 	public void testSetValue() {
 		MapAdaptable<String, String> testMap = new TestMapAdaptable();
 		context.getELResolver().setValue(context, testMap, "foo", "foo");
@@ -48,6 +57,7 @@ public class MapAdaptableELResolverTests extends TestCase {
 		assertEquals("foo", testMap.asMap().get("foo"));
 	}
 
+	@Test
 	public void testSetValue_OverWrite() {
 		MapAdaptable<String, String> testMap = new TestMapAdaptable();
 		context.getELResolver().setValue(context, testMap, "bar", "foo");

--- a/spring-binding/src/test/java/org/springframework/binding/expression/spel/ELExpressionParserCompatibilityTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/expression/spel/ELExpressionParserCompatibilityTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.binding.expression.spel;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.EvaluationException;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionVariable;
@@ -40,20 +44,23 @@ import org.springframework.expression.spel.standard.SpelExpressionParser;
  * 
  * @author Rossen Stoyanchev
  */
-public class ELExpressionParserCompatibilityTests extends TestCase {
+public class ELExpressionParserCompatibilityTests {
 
 	private SpringELExpressionParser parser = new SpringELExpressionParser(new SpelExpressionParser());
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		parser.addPropertyAccessor(new SpecialPropertyAccessor());
 	}
 
+	@Test
 	public void testParseSimpleEvalExpressionNoParserContext() {
 		String expressionString = "3 + 4";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals(7, exp.getValue(null)); // Unified EL returns Long
 	}
 
+	@Test
 	public void testParseNullExpressionString() {
 		String expressionString = null;
 		try {
@@ -64,11 +71,13 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseNull() {
 		Expression exp = parser.parseExpression("null", null);
 		assertEquals(null, exp.getValue(null));
 	}
 
+	@Test
 	public void testParseEmptyExpressionString() {
 		String expressionString = "";
 		try {
@@ -79,18 +88,21 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseSimpleEvalExpressionNoEvalContextWithTypeCoersion() {
 		String expressionString = "3 + 4";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().expectResult(Long.class));
 		assertEquals(7L, exp.getValue(null));
 	}
 
+	@Test
 	public void testParseBeanEvalExpressionNoParserContext() {
 		String expressionString = "value";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("foo", exp.getValue(new TestBean()));
 	}
 
+	@Test
 	public void testParseEvalExpressionWithContextTypeCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser
@@ -98,12 +110,14 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals(2, exp.getValue(new TestBean()));
 	}
 
+	@Test
 	public void testParseEvalExpressionWithContextCustomELVariableResolver() {
 		String expressionString = "specialProperty";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().evaluate(TestBean.class));
 		assertEquals("Custom resolver resolved this special property!", exp.getValue(null));
 	}
 
+	@Test
 	public void testParseBeanEvalExpressionInvalidELVariable() {
 		try {
 			String expressionString = "bogus";
@@ -116,12 +130,14 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseLiteralExpression() {
 		String expressionString = "'value'";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("value", exp.getValue(null));
 	}
 
+	@Test
 	public void testParseTemplateExpression() {
 		String expressionString = "text text text #{value} text text text#{value}";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().template());
@@ -129,6 +145,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals("text text text foo text text textfoo", exp.getValue(target));
 	}
 
+	@Test
 	public void testParseTemplateExpressionWithVariables() {
 		String expressionString = "#{value}#{#max}";
 		Expression exp = parser.parseExpression(expressionString,
@@ -137,12 +154,14 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals("foo2", exp.getValue(target)); // TODO:
 	}
 
+	@Test
 	public void testGetExpressionString() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
 		assertEquals("maximum", exp.getExpressionString());
 	}
 
+	@Test
 	public void testGetExpressionType() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -151,6 +170,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertTrue(int.class.equals(clazz) || Integer.class.equals(clazz));
 	}
 
+	@Test
 	public void testGetValueWithCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, new FluentParserContext().expectResult(String.class));
@@ -158,6 +178,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals("2", exp.getValue(context));
 	}
 
+	@Test
 	public void testGetValueCoersionError() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString,
@@ -170,6 +191,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testSetValue() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -178,6 +200,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals(5, context.getMaximum());
 	}
 
+	@Test
 	public void testSetValueWithTypeCoersion() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);
@@ -186,6 +209,7 @@ public class ELExpressionParserCompatibilityTests extends TestCase {
 		assertEquals(5, context.getMaximum());
 	}
 
+	@Test
 	public void testSetValueCoersionError() {
 		String expressionString = "maximum";
 		Expression exp = parser.parseExpression(expressionString, null);

--- a/spring-binding/src/test/java/org/springframework/binding/mapping/DefaultMapperTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/mapping/DefaultMapperTests.java
@@ -1,21 +1,25 @@
 package org.springframework.binding.mapping;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.spel.SpringELExpressionParser;
 import org.springframework.binding.mapping.impl.DefaultMapper;
 import org.springframework.binding.mapping.impl.DefaultMapping;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 
-public class DefaultMapperTests extends TestCase {
+public class DefaultMapperTests {
 	private DefaultMapper mapper = new DefaultMapper();
 	private ExpressionParser parser = new SpringELExpressionParser(new SpelExpressionParser());
 
+	@Test
 	public void testMapping() {
 		DefaultMapping mapping1 = new DefaultMapping(parser.parseExpression("foo", null), parser.parseExpression("bar",
 				null));
@@ -43,6 +47,7 @@ public class DefaultMapperTests extends TestCase {
 		}).size());
 	}
 
+	@Test
 	public void testMappingConversion() {
 		DefaultMapping mapping1 = new DefaultMapping(parser.parseExpression("beep", null), parser.parseExpression(
 				"beep", null));
@@ -55,6 +60,7 @@ public class DefaultMapperTests extends TestCase {
 		assertEquals(Locale.ENGLISH, bean2.beep);
 	}
 
+	@Test
 	public void testMappingConversionError() {
 		DefaultMapping mapping1 = new DefaultMapping(parser.parseExpression("boop", null), parser.parseExpression(
 				"boop", null));

--- a/spring-binding/src/test/java/org/springframework/binding/message/DefaultMessageContextTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/message/DefaultMessageContextTests.java
@@ -1,22 +1,26 @@
 package org.springframework.binding.message;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.support.StaticMessageSource;
 
-public class DefaultMessageContextTests extends TestCase {
+public class DefaultMessageContextTests {
 	private DefaultMessageContext context;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StaticMessageSource messageSource = new StaticMessageSource();
 		messageSource.addMessage("message", Locale.getDefault(), "Hello world resolved!");
 		messageSource.addMessage("argmessage", Locale.getDefault(), "Hello world {0}!");
 		context = new DefaultMessageContext(messageSource);
 	}
 
+	@Test
 	public void testCreateMessageContext() {
 		context.addMessage(new MessageBuilder().defaultText("Hello world!").build());
 		Message[] messages = context.getAllMessages();
@@ -26,6 +30,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(null, messages[0].getSource());
 	}
 
+	@Test
 	public void testResolveMessage() {
 		context.addMessage(new MessageBuilder().warning().source(this).code("message").build());
 		Message[] messages = context.getMessagesBySource(this);
@@ -35,6 +40,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(this, messages[0].getSource());
 	}
 
+	@Test
 	public void testResolveMessageDefaultText() {
 		context.addMessage(new MessageBuilder().error().code("bogus").defaultText("Hello world fallback!").build());
 		Message[] messages = context.getAllMessages();
@@ -44,6 +50,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(null, messages[0].getSource());
 	}
 
+	@Test
 	public void testResolveMessageWithArgs() {
 		context.addMessage(new MessageBuilder().error().source(this).code("argmessage").arg("Keith")
 				.defaultText("Hello world fallback!").build());
@@ -54,6 +61,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(this, messages[0].getSource());
 	}
 
+	@Test
 	public void testResolveMessageWithMultipleCodes() {
 		context.addMessage(new MessageBuilder().error().source(this).code("bogus").code("argmessage").arg("Keith")
 				.defaultText("Hello world fallback!").build());
@@ -64,6 +72,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(this, messages[0].getSource());
 	}
 
+	@Test
 	public void testSaveRestoreMessages() {
 		context.addMessage(new MessageBuilder().defaultText("Info").build());
 		context.addMessage(new MessageBuilder().error().defaultText("Error").build());
@@ -80,6 +89,7 @@ public class DefaultMessageContextTests extends TestCase {
 		assertEquals(1, context.getMessagesBySource(this).length);
 	}
 
+	@Test
 	public void testMessageSequencing() {
 		context.addMessage(new MessageBuilder().defaultText("Info").build());
 		context.addMessage(new MessageBuilder().warning().source(this).code("message").build());

--- a/spring-binding/src/test/java/org/springframework/binding/message/MessageBuilderTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/message/MessageBuilderTests.java
@@ -1,23 +1,29 @@
 package org.springframework.binding.message;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.NoSuchMessageException;
 import org.springframework.context.support.StaticMessageSource;
 
-public class MessageBuilderTests extends TestCase {
+public class MessageBuilderTests {
 	private StaticMessageSource messageSource = new StaticMessageSource();
 	private Locale locale = Locale.getDefault();
 	private MessageBuilder builder = new MessageBuilder();
 
+	@Before
 	public void setUp() {
 		messageSource.addMessage("foo", locale, "bar");
 		messageSource.addMessage("bar", locale, "{0}");
 		messageSource.addMessage("baz", locale, "boop");
 	}
 
+	@Test
 	public void testBuildDefaultText() {
 		MessageResolver resolver = builder.defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -26,6 +32,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildFatal() {
 		MessageResolver resolver = builder.fatal().defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -34,6 +41,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildError() {
 		MessageResolver resolver = builder.error().defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -42,6 +50,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildWarning() {
 		MessageResolver resolver = builder.warning().defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -50,6 +59,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildNothing() {
 		MessageResolver resolver = builder.build();
 		try {
@@ -60,6 +70,7 @@ public class MessageBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBuildCode() {
 		MessageResolver resolver = builder.error().code("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -68,6 +79,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildCodes() {
 		MessageResolver resolver = builder.error().codes("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -76,6 +88,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildArg() {
 		MessageResolver resolver = builder.error().code("bar").arg("baz").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -84,6 +97,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildArgs() {
 		MessageResolver resolver = builder.error().codes("bar").args("baz").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -92,6 +106,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildCodesNull() {
 		MessageResolver resolver = builder.codes().build();
 		try {
@@ -102,6 +117,7 @@ public class MessageBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBuildArgsNull() {
 		MessageResolver resolver = builder.args().build();
 		try {
@@ -112,6 +128,7 @@ public class MessageBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBuildArgsWithNullCodes() {
 		MessageResolver resolver = builder.error().args("baz").build();
 		try {
@@ -121,12 +138,14 @@ public class MessageBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBuildArgsWithNullCodesDefaultText() {
 		MessageResolver resolver = builder.error().args("baz").defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
 		assertEquals("foo", message.getText());
 	}
 
+	@Test
 	public void testBuildWithSource() {
 		MessageResolver resolver = builder.source("foo").defaultText("foo").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -135,6 +154,7 @@ public class MessageBuilderTests extends TestCase {
 		assertEquals(Severity.INFO, message.getSeverity());
 	}
 
+	@Test
 	public void testBuildResolvableArg() {
 		MessageResolver resolver = builder.error().code("bar").resolvableArg("baz").build();
 		Message message = resolver.resolveMessage(messageSource, locale);
@@ -143,6 +163,7 @@ public class MessageBuilderTests extends TestCase {
 		assertNull(message.getSource());
 	}
 
+	@Test
 	public void testBuildResolvableArgs() {
 		MessageResolver resolver = builder.error().codes("bar").resolvableArgs("baz")
 				.build();

--- a/spring-binding/src/test/java/org/springframework/binding/message/MessageContextErrorsMessageCodesTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/message/MessageContextErrorsMessageCodesTests.java
@@ -2,13 +2,13 @@ package org.springframework.binding.message;
 
 import java.util.Locale;
 
-import junit.framework.TestCase;
 import org.easymock.EasyMock;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.validation.MessageCodesResolver;
 
-public class MessageContextErrorsMessageCodesTests extends TestCase {
+public class MessageContextErrorsMessageCodesTests {
 
 	private DefaultMessageContext context;
 
@@ -18,8 +18,8 @@ public class MessageContextErrorsMessageCodesTests extends TestCase {
 
 	private MessageCodesResolver resolver;
 
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StaticMessageSource messageSource = new StaticMessageSource();
 		messageSource.addMessage(errorCode, Locale.getDefault(), "doesntmatter");
 		context = new DefaultMessageContext(messageSource);
@@ -27,6 +27,7 @@ public class MessageContextErrorsMessageCodesTests extends TestCase {
 		resolver = EasyMock.createMock(MessageCodesResolver.class);
 	}
 
+	@Test
 	public void testRejectUsesObjectName() {
 		EasyMock.expect(resolver.resolveMessageCodes(errorCode, objectName)).andReturn(new String[] {});
 		EasyMock.replay(resolver);
@@ -38,6 +39,7 @@ public class MessageContextErrorsMessageCodesTests extends TestCase {
 		EasyMock.verify(resolver);
 	}
 
+	@Test
 	public void testRejectValueUsesObjectName() {
 		EasyMock.expect(resolver.resolveMessageCodes(errorCode, objectName, "field", null)).andReturn(new String[] {});
 		EasyMock.replay(resolver);
@@ -48,6 +50,7 @@ public class MessageContextErrorsMessageCodesTests extends TestCase {
 		EasyMock.verify(resolver);
 	}
 
+	@Test
 	public void testRejectValueEmptyField() {
 		EasyMock.expect(resolver.resolveMessageCodes(errorCode, objectName)).andReturn(new String[] {});
 		EasyMock.replay(resolver);

--- a/spring-binding/src/test/java/org/springframework/binding/message/MessageContextErrorsTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/message/MessageContextErrorsTests.java
@@ -1,23 +1,25 @@
 package org.springframework.binding.message;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.spel.SpringELExpressionParser;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.validation.DefaultMessageCodesResolver;
 import org.springframework.validation.MapBindingResult;
 
-public class MessageContextErrorsTests extends TestCase {
+public class MessageContextErrorsTests {
 
 	private DefaultMessageContext context;
 	private MessageContextErrors errors;
 
-	@Override
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StaticMessageSource messageSource = new StaticMessageSource();
 		messageSource.addMessage("foo", Locale.getDefault(), "bar");
 		messageSource.addMessage("bar", Locale.getDefault(), "{0}");
@@ -29,6 +31,7 @@ public class MessageContextErrorsTests extends TestCase {
 		errors = new MessageContextErrors(context, "object", new Object(), parser, resolver, null);
 	}
 
+	@Test
 	public void testReject() {
 		errors.reject("foo");
 		errors.reject("bogus", "baz");
@@ -50,6 +53,7 @@ public class MessageContextErrorsTests extends TestCase {
 		assertEquals(Severity.ERROR, msg.getSeverity());
 	}
 
+	@Test
 	public void testRejectValue() {
 		errors.rejectValue("class", "foo");
 		errors.rejectValue("class", "bogus", "baz");
@@ -71,6 +75,7 @@ public class MessageContextErrorsTests extends TestCase {
 		assertEquals(Severity.ERROR, msg.getSeverity());
 	}
 
+	@Test
 	public void testGlobalError() {
 		errors.rejectValue(null, "bar", new Object[] { "boop" }, null);
 		Message msg = context.getAllMessages()[0];
@@ -79,6 +84,7 @@ public class MessageContextErrorsTests extends TestCase {
 		assertEquals(Severity.ERROR, msg.getSeverity());
 	}
 
+	@Test
 	public void testAddAllErrors() {
 		MapBindingResult result = new MapBindingResult(new HashMap<>(), "object");
 		result.reject("bar", new Object[] { "boop" }, null);
@@ -96,14 +102,17 @@ public class MessageContextErrorsTests extends TestCase {
 		assertEquals(Severity.ERROR, msg.getSeverity());
 	}
 
+	@Test
 	public void testGetGlobalErrors() {
 
 	}
 
+	@Test
 	public void testGetFieldErrors() {
 
 	}
 
+	@Test
 	public void testGetFieldValue() {
 
 	}

--- a/spring-binding/src/test/java/org/springframework/binding/method/MethodInvocationExceptionTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/method/MethodInvocationExceptionTests.java
@@ -15,18 +15,21 @@
  */
 package org.springframework.binding.method;
 
+import static org.junit.Assert.assertSame;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test case for {@link MethodInvocationException}.
  * 
  * @author Erwin Vervaet
  */
-public class MethodInvocationExceptionTests extends TestCase {
+public class MethodInvocationExceptionTests {
 
+	@Test
 	public void testGetTargetException() {
 		// runtime exception
 		IllegalArgumentException iae = new IllegalArgumentException("test");

--- a/spring-binding/src/test/java/org/springframework/binding/method/MethodInvokerTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/method/MethodInvokerTests.java
@@ -15,8 +15,13 @@
  */
 package org.springframework.binding.method;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 
 /**
@@ -25,14 +30,16 @@ import org.springframework.binding.expression.support.StaticExpression;
  * @author Erwin Vervaet
  * @author Jeremy Grelle
  */
-public class MethodInvokerTests extends TestCase {
+public class MethodInvokerTests {
 
 	private MethodInvoker methodInvoker;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		this.methodInvoker = new MethodInvoker();
 	}
 
+	@Test
 	public void testInvocationTargetException() {
 		try {
 			methodInvoker.invoke(new MethodSignature("test"), new TestObject(), null);
@@ -43,6 +50,7 @@ public class MethodInvokerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testInvalidMethod() {
 		try {
 			methodInvoker.invoke(new MethodSignature("bogus"), new TestObject(), null);
@@ -52,6 +60,7 @@ public class MethodInvokerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBeanArg() {
 		Parameters parameters = new Parameters();
 		Bean bean = new Bean();
@@ -60,6 +69,7 @@ public class MethodInvokerTests extends TestCase {
 		assertSame(bean, methodInvoker.invoke(method, new TestObject(), null));
 	}
 
+	@Test
 	public void testPrimitiveArg() {
 		Parameters parameters = new Parameters();
 		parameters.add(new Parameter(Boolean.class, new StaticExpression(true)));

--- a/spring-binding/src/test/java/org/springframework/binding/method/MethodKeyTests.java
+++ b/spring-binding/src/test/java/org/springframework/binding/method/MethodKeyTests.java
@@ -15,46 +15,53 @@
  */
 package org.springframework.binding.method;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.File;
 import java.io.FilenameFilter;
 import java.lang.reflect.Method;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * @author Rob Harrop
  * @since 1.0
  */
-public class MethodKeyTests extends TestCase {
+public class MethodKeyTests {
 
 	private static final Method LIST_NO_ARGS = safeGetMethod(File.class, "list", null);
 
 	private static final Method LIST_FILENAME_FILTER = safeGetMethod(File.class, "list",
 			new Class[] { FilenameFilter.class });
 
+	@Test
 	public void testGetMethodWithNoArgs() {
 		MethodKey key = new MethodKey(File.class, "list");
 		Method m = key.getMethod();
 		assertEquals(LIST_NO_ARGS, m);
 	}
 
+	@Test
 	public void testGetMoreGenericMethod() {
 		MethodKey key = new MethodKey(Object.class, "equals", Long.class);
 		assertEquals(safeGetMethod(Object.class, "equals", new Class[] { Object.class }), key.getMethod());
 	}
 
+	@Test
 	public void testGetMethodWithSingleArg() {
 		MethodKey key = new MethodKey(File.class, "list", FilenameFilter.class);
 		Method m = key.getMethod();
 		assertEquals(LIST_FILENAME_FILTER, m);
 	}
 
+	@Test
 	public void testGetMethodWithSingleNullArgAndValidMatch() {
 		MethodKey key = new MethodKey(File.class, "list", new Class[] { null });
 		Method m = key.getMethod();
 		assertEquals(LIST_FILENAME_FILTER, m);
 	}
 
+	@Test
 	public void testGetMethodWithSingleNullAndUnclearMatch() {
 		new MethodKey(File.class, "listFiles", new Class[] { null });
 	}

--- a/spring-faces/src/test/java/org/springframework/faces/config/AbstractFacesFlowBuilderServicesConfigurationTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/config/AbstractFacesFlowBuilderServicesConfigurationTests.java
@@ -1,7 +1,12 @@
 package org.springframework.faces.config;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionException;
 import org.springframework.binding.convert.ConversionExecutionException;
 import org.springframework.binding.convert.ConversionExecutor;
@@ -23,7 +28,7 @@ import org.springframework.webflow.execution.ViewFactory;
 import org.springframework.webflow.expression.spel.WebFlowSpringELExpressionParser;
 import org.springframework.webflow.validation.ValidationHintResolver;
 
-public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends TestCase {
+public abstract class AbstractFacesFlowBuilderServicesConfigurationTests {
 
 	protected ApplicationContext context;
 
@@ -31,7 +36,7 @@ public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends
 
 	protected final JSFMockHelper jsf = new JSFMockHelper();
 
-
+	@Before
 	public void setUp() throws Exception {
 		this.jsf.setUp();
 		this.context = initApplicationContext();
@@ -39,10 +44,12 @@ public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends
 
 	protected abstract ApplicationContext initApplicationContext();
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		this.jsf.tearDown();
 	}
 
+	@Test
 	public void testConfigureDefaults() {
 		this.builderServices = (FlowBuilderServices) this.context.getBean("flowBuilderServicesDefault");
 		assertNotNull(this.builderServices);
@@ -52,6 +59,7 @@ public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends
 		assertFalse(this.builderServices.getDevelopment());
 	}
 
+	@Test
 	public void testEnableManagedBeans() {
 		this.builderServices = (FlowBuilderServices) this.context.getBean("flowBuilderServicesLegacy");
 		assertNotNull(this.builderServices);
@@ -61,6 +69,7 @@ public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends
 		assertFalse(this.builderServices.getDevelopment());
 	}
 
+	@Test
 	public void testFlowBuilderServicesAllCustomized() {
 		this.builderServices = (FlowBuilderServices) this.context.getBean("flowBuilderServicesAllCustom");
 		assertNotNull(this.builderServices);
@@ -72,6 +81,7 @@ public abstract class AbstractFacesFlowBuilderServicesConfigurationTests extends
 		assertTrue(this.builderServices.getDevelopment());
 	}
 
+	@Test
 	public void testFlowBuilderServicesConversionServiceCustomized() {
 		this.builderServices = (FlowBuilderServices) this.context.getBean("flowBuilderServicesConversionServiceCustom");
 		assertNotNull(this.builderServices);

--- a/spring-faces/src/test/java/org/springframework/faces/config/AbstractResourcesConfigurationTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/config/AbstractResourcesConfigurationTests.java
@@ -1,27 +1,36 @@
 package org.springframework.faces.config;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.faces.webflow.JsfResourceRequestHandler;
 import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter;
 
-public abstract class AbstractResourcesConfigurationTests extends TestCase {
+public abstract class AbstractResourcesConfigurationTests {
 
 	protected ApplicationContext context;
 
+	@Before
 	public void setUp() throws Exception {
 		this.context = initApplicationContext();
 	}
 
 	protected abstract ApplicationContext initApplicationContext();
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 	}
 
+	@Test
 	public void testConfigureDefaults() {
 		Map<String, ?> map = this.context.getBeansOfType(HttpRequestHandlerAdapter.class);
 		assertEquals(1, map.values().size());

--- a/spring-faces/src/test/java/org/springframework/faces/config/ResourcesBeanDefinitionParserTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/config/ResourcesBeanDefinitionParserTests.java
@@ -1,5 +1,7 @@
 package org.springframework.faces.config;
 
+import org.junit.After;
+import org.junit.Before;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.faces.webflow.JSFMockHelper;
@@ -11,13 +13,16 @@ public class ResourcesBeanDefinitionParserTests extends AbstractResourcesConfigu
 	 */
 	private final JSFMockHelper jsfMockHelper = new JSFMockHelper();
 
+	@Override
+	@Before
 	public void setUp() throws Exception {
 		this.jsfMockHelper.setUp();
 		super.setUp();
 	}
 
 	@Override
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		super.tearDown();
 		this.jsfMockHelper.tearDown();
 	}

--- a/spring-faces/src/test/java/org/springframework/faces/model/SelectionTrackingActionListenerTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/model/SelectionTrackingActionListenerTests.java
@@ -1,5 +1,9 @@
 package org.springframework.faces.model;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,15 +17,17 @@ import javax.faces.event.AbortProcessingException;
 import javax.faces.event.ActionEvent;
 import javax.faces.event.ActionListener;
 
-import junit.framework.TestCase;
 
 import org.apache.myfaces.test.mock.MockFacesContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.faces.webflow.JSFMockHelper;
 import org.springframework.util.ReflectionUtils;
 
 import com.sun.faces.facelets.component.UIRepeat;
 
-public class SelectionTrackingActionListenerTests extends TestCase {
+public class SelectionTrackingActionListenerTests {
 
 	/**
 	 * JSF Mock Helper
@@ -48,6 +54,7 @@ public class SelectionTrackingActionListenerTests extends TestCase {
 	 */
 	private final ActionListener selectionTrackingListener = new SelectionTrackingActionListener(this.delegateListener);
 
+	@Before
 	public void setUp() throws Exception {
 		this.jsfMockHelper.setUp();
 		this.viewToTest = new UIViewRoot();
@@ -58,10 +65,12 @@ public class SelectionTrackingActionListenerTests extends TestCase {
 		this.dataModel = new OneSelectionTrackingListDataModel<>(rows);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMockHelper.tearDown();
 	}
 
+	@Test
 	public void testProcessActionWithUIData() {
 
 		UIData dataTable = new UIData();
@@ -86,6 +95,7 @@ public class SelectionTrackingActionListenerTests extends TestCase {
 		assertTrue(this.dataModel.getSelectedRow() != this.dataModel.getRowData());
 	}
 
+	@Test
 	public void testProcessActionWithUIRepeat() {
 
 		UIRepeat uiRepeat = new UIRepeat();

--- a/spring-faces/src/test/java/org/springframework/faces/model/converter/DataModelConverterTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/model/converter/DataModelConverterTests.java
@@ -1,5 +1,10 @@
 package org.springframework.faces.model.converter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -7,16 +12,16 @@ import java.util.List;
 import javax.faces.model.DataModel;
 import javax.faces.model.ListDataModel;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.binding.convert.converters.Converter;
 import org.springframework.faces.model.SerializableListDataModel;
 
-public class DataModelConverterTests extends TestCase {
+public class DataModelConverterTests {
 
 	Converter converter = new DataModelConverter();
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testConvertListToDataModel() throws Exception {
 		List<Object> sourceList = new ArrayList<>();
 
@@ -28,6 +33,7 @@ public class DataModelConverterTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testConvertListToListDataModel() throws Exception {
 		List<Object> sourceList = new ArrayList<>();
 
@@ -39,6 +45,7 @@ public class DataModelConverterTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testConvertListToSerializableListDataModel() throws Exception {
 		List<Object> sourceList = new ArrayList<>();
 
@@ -51,6 +58,7 @@ public class DataModelConverterTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testConvertListToSerializableListDataModelNullSource() throws Exception {
 		List<Object> sourceList = null;
 

--- a/spring-faces/src/test/java/org/springframework/faces/model/converter/FacesConversionServiceTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/model/converter/FacesConversionServiceTests.java
@@ -5,17 +5,19 @@ import java.util.List;
 
 import javax.faces.model.DataModel;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionExecutor;
 
-public class FacesConversionServiceTests extends TestCase {
+public class FacesConversionServiceTests {
 	private FacesConversionService service;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.service = new FacesConversionService();
 	}
 
+	@Test
 	public void testGetAbstractType() {
 		ConversionExecutor executor = this.service.getConversionExecutor(List.class, DataModel.class);
 		ArrayList<Object> list = new ArrayList<>();

--- a/spring-faces/src/test/java/org/springframework/faces/mvc/JsfViewTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/mvc/JsfViewTests.java
@@ -1,13 +1,18 @@
 package org.springframework.faces.mvc;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Locale;
 
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.faces.webflow.JSFMockHelper;
 import org.springframework.faces.webflow.MockViewHandler;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -17,12 +22,13 @@ import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 
-public class JsfViewTests extends TestCase {
+public class JsfViewTests {
 
 	UrlBasedViewResolver resolver;
 
 	private final JSFMockHelper jsfMock = new JSFMockHelper();
 
+	@Before
 	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 		this.jsfMock.facesContext().getApplication().setViewHandler(new ResourceCheckingViewHandler());
@@ -34,15 +40,18 @@ public class JsfViewTests extends TestCase {
 		this.resolver.setApplicationContext(new StaticWebApplicationContext());
 	}
 
+	@After
 	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 	}
 
+	@Test
 	public void testViewResolution() throws Exception {
 		View view = this.resolver.resolveViewName("intro", new Locale("EN"));
 		assertTrue(view instanceof JsfView);
 	}
 
+	@Test
 	public void testViewRender() throws Exception {
 		JsfView view = (JsfView) this.resolver.resolveViewName("intro", new Locale("EN"));
 		view.setApplicationContext(new StaticWebApplicationContext());

--- a/spring-faces/src/test/java/org/springframework/faces/security/FaceletsAuthorizeTagTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/security/FaceletsAuthorizeTagTests.java
@@ -15,50 +15,59 @@
  */
 package org.springframework.faces.security;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link FaceletsAuthorizeTag}.
  * @author Rossen Stoyanchev
  */
-public class FaceletsAuthorizeTagTests extends TestCase {
+public class FaceletsAuthorizeTagTests {
 
+	@Test
 	public void testIfAllGrantedWithOneRole() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfAllGranted("ROLE_A");
 		assertEquals("hasRole('ROLE_A')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfAllGrantedWithMultipleRoles() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfAllGranted("ROLE_A, ROLE_B, ROLE_C");
 		assertEquals("hasRole('ROLE_A') and hasRole('ROLE_B') and hasRole('ROLE_C')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfAnyGrantedWithOneRole() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfAnyGranted("ROLE_A");
 		assertEquals("hasAnyRole('ROLE_A')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfAnyGrantedWithMultipleRole() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfAnyGranted("ROLE_A, ROLE_B, ROLE_C");
 		assertEquals("hasAnyRole('ROLE_A','ROLE_B','ROLE_C')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfNoneGrantedWithOneRole() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfNotGranted("ROLE_A");
 		assertEquals("!hasAnyRole('ROLE_A')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfNoneGrantedWithMultipleRole() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfNotGranted("ROLE_A, ROLE_B, ROLE_C");
 		assertEquals("!hasAnyRole('ROLE_A','ROLE_B','ROLE_C')", tag.getAccess());
 	}
 
+	@Test
 	public void testIfAllAnyNotGranted() {
 		FaceletsAuthorizeTag tag = new FaceletsAuthorizeTag();
 		tag.setIfAllGranted("ROLE_A");

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/FlowActionListenerTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/FlowActionListenerTests.java
@@ -1,21 +1,26 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import javax.el.ELContext;
 import javax.el.MethodExpression;
 import javax.el.MethodInfo;
 import javax.faces.component.UICommand;
 import javax.faces.event.ActionEvent;
 
-import junit.framework.TestCase;
 import org.easymock.EasyMock;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.ViewState;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.RequestContextHolder;
 
-public class FlowActionListenerTests extends TestCase {
+public class FlowActionListenerTests {
 
 	FlowActionListener listener;
 
@@ -23,7 +28,8 @@ public class FlowActionListenerTests extends TestCase {
 
 	RequestContext context = EasyMock.createMock(RequestContext.class);
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 
 		this.listener = new FlowActionListener(this.jsfMock.application().getActionListener());
@@ -34,12 +40,13 @@ public class FlowActionListenerTests extends TestCase {
 		EasyMock.replay(this.context);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public final void testProcessAction() {
 
 		String outcome = "foo";
@@ -56,6 +63,7 @@ public class FlowActionListenerTests extends TestCase {
 				this.jsfMock.externalContext().getRequestMap().get(JsfView.EVENT_KEY));
 	}
 
+	@Test
 	public final void testProcessAction_NullOutcome() {
 
 		String outcome = null;

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/FlowELResolverTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/FlowELResolverTests.java
@@ -1,10 +1,18 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import javax.el.ELContext;
 
-import junit.framework.TestCase;
 import org.apache.myfaces.test.el.MockELContext;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
@@ -18,7 +26,7 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Phillip Webb
  */
-public class FlowELResolverTests extends TestCase {
+public class FlowELResolverTests {
 
 	private final FlowELResolver resolver = new FlowELResolver();
 
@@ -26,14 +34,17 @@ public class FlowELResolverTests extends TestCase {
 
 	private final ELContext elContext = new MockELContext();
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		RequestContextHolder.setRequestContext(this.requestContext);
 	}
 
-	protected void tearDown() {
+	@After
+	public void tearDown() {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testRequestContextResolve() {
 		Object actual = this.resolver.getValue(this.elContext, null, "flowRequestContext");
 		assertTrue(this.elContext.isPropertyResolved());
@@ -41,6 +52,7 @@ public class FlowELResolverTests extends TestCase {
 		assertSame(this.requestContext, actual);
 	}
 
+	@Test
 	public void testImplicitFlowResolve() {
 		Object actual = this.resolver.getValue(this.elContext, null, "flowScope");
 		assertTrue(this.elContext.isPropertyResolved());
@@ -48,6 +60,7 @@ public class FlowELResolverTests extends TestCase {
 		assertSame(this.requestContext.getFlowScope(), actual);
 	}
 
+	@Test
 	public void testFlowResourceResolve() {
 		ApplicationContext applicationContext = new StaticWebApplicationContext();
 		((Flow) this.requestContext.getActiveFlow()).setApplicationContext(applicationContext);
@@ -57,6 +70,7 @@ public class FlowELResolverTests extends TestCase {
 		assertSame(applicationContext, actual);
 	}
 
+	@Test
 	public void testScopeResolve() {
 		this.requestContext.getFlowScope().put("test", "test");
 		Object actual = this.resolver.getValue(this.elContext, null, "test");
@@ -64,6 +78,7 @@ public class FlowELResolverTests extends TestCase {
 		assertEquals("test", actual);
 	}
 
+	@Test
 	public void testMapAdaptableResolve() {
 		LocalAttributeMap<String> base = new LocalAttributeMap<>();
 		base.put("test", "test");
@@ -72,6 +87,7 @@ public class FlowELResolverTests extends TestCase {
 		assertEquals("test", actual);
 	}
 
+	@Test
 	public void testBeanResolveWithRequestContext() {
 		StaticWebApplicationContext applicationContext = new StaticWebApplicationContext();
 		((Flow) this.requestContext.getActiveFlow()).setApplicationContext(applicationContext);
@@ -82,6 +98,7 @@ public class FlowELResolverTests extends TestCase {
 		assertTrue(actual instanceof Bean);
 	}
 
+	@Test
 	public void testBeanResolveWithoutRequestContext() {
 		RequestContextHolder.setRequestContext(null);
 		Object actual = this.resolver.getValue(this.elContext, null, "test");

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/FlowFacesContextTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/FlowFacesContextTests.java
@@ -1,5 +1,10 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -12,9 +17,10 @@ import java.util.List;
 import javax.faces.application.FacesMessage;
 import javax.faces.context.FacesContext;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.message.DefaultMessageContext;
 import org.springframework.binding.message.Message;
 import org.springframework.binding.message.MessageBuilder;
@@ -22,7 +28,7 @@ import org.springframework.binding.message.MessageContext;
 import org.springframework.faces.webflow.FlowFacesContext.FacesMessageSource;
 import org.springframework.webflow.execution.RequestContext;
 
-public class FlowFacesContextTests extends TestCase {
+public class FlowFacesContextTests {
 
 	JSFMockHelper jsf = new JSFMockHelper();
 
@@ -35,22 +41,25 @@ public class FlowFacesContextTests extends TestCase {
 	MessageContext prepopulatedMessageContext;
 
 	@SuppressWarnings("cast")
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsf.setUp();
 		this.requestContext = (RequestContext) EasyMock.createMock(RequestContext.class);
 		this.facesContext = new FlowFacesContext(this.requestContext, this.jsf.facesContext());
 		setupMessageContext();
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsf.tearDown();
 	}
 
+	@Test
 	public final void testCurrentInstance() {
 		assertSame(FacesContext.getCurrentInstance(), this.facesContext);
 	}
 
+	@Test
 	public final void testAddMessage() {
 		this.messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -63,6 +72,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals("foo : bar", message.getText());
 	}
 
+	@Test
 	public final void testGetGlobalMessagesOnly() {
 		this.messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -81,6 +91,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(1, iterationCount);
 	}
 
+	@Test
 	public final void testGetAllMessages() {
 		this.messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -99,6 +110,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(2, iterationCount);
 	}
 
+	@Test
 	public final void testAddMessages_MultipleNullIds() {
 		this.messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -113,6 +125,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals("zoo : zar", messages[1].getText());
 	}
 
+	@Test
 	public final void testGetMessages() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -127,6 +140,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals("There should be 6 messages to iterate", 6, iterationCount);
 	}
 
+	@Test
 	public final void testMutableGetMessages() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -145,6 +159,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals("summary2", gotMessage.getSummary());
 	}
 
+	@Test
 	public final void testGetMessagesByClientId_ForComponent() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -162,6 +177,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(2, iterationCount);
 	}
 
+	@Test
 	public final void testGetMessagesByClientId_ForUserMessage() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -179,6 +195,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(1, iterationCount);
 	}
 
+	@Test
 	public final void testgetMessagesByClientId_InvalidId() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -188,6 +205,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertFalse(i.hasNext());
 	}
 
+	@Test
 	public final void testGetClientIdsWithMessages() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -208,6 +226,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(3, iterationCount);
 	}
 
+	@Test
 	public final void testMessagesAreSerializable() throws Exception {
 		DefaultMessageContext messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(messageContext);
@@ -243,6 +262,7 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(FacesMessage.SEVERITY_FATAL, gotMessage.getSeverity());
 	}
 
+	@Test
 	public final void testGetMaximumSeverity() {
 		this.messageContext = this.prepopulatedMessageContext;
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);
@@ -251,12 +271,14 @@ public class FlowFacesContextTests extends TestCase {
 		assertEquals(FacesMessage.SEVERITY_FATAL, this.facesContext.getMaximumSeverity());
 	}
 
+	@Test
 	public final void testGetELContext() {
 
 		assertNotNull(this.facesContext.getELContext());
 		assertSame(this.facesContext, this.facesContext.getELContext().getContext(FacesContext.class));
 	}
 
+	@Test
 	public final void testValidationFailed() {
 		this.messageContext = new DefaultMessageContext();
 		EasyMock.expect(this.requestContext.getMessageContext()).andStubReturn(this.messageContext);

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/FlowPartialViewContextTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/FlowPartialViewContextTests.java
@@ -1,5 +1,7 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -7,20 +9,21 @@ import java.util.List;
 import javax.faces.context.PartialViewContext;
 import javax.faces.context.PartialViewContextWrapper;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Test;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.execution.View;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class FlowPartialViewContextTests extends TestCase {
+public class FlowPartialViewContextTests {
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testReturnFragmentIds() {
 		String[] fragmentIds = new String[] { "foo", "bar" };
 
@@ -31,6 +34,7 @@ public class FlowPartialViewContextTests extends TestCase {
 		assertEquals(Arrays.asList(fragmentIds), new FlowPartialViewContext(null).getRenderIds());
 	}
 
+	@Test
 	public void testNoFragmentIds() {
 		final List<String> renderIds = Arrays.asList("foo", "bar");
 		FlowPartialViewContext context = new FlowPartialViewContext(new PartialViewContextWrapper() {
@@ -51,6 +55,7 @@ public class FlowPartialViewContextTests extends TestCase {
 		assertEquals(renderIds, context.getRenderIds());
 	}
 
+	@Test
 	public void testReturnFragmentIdsMutable() {
 		String[] fragmentIds = new String[] { "foo", "bar" };
 

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/FlowResponseStateManagerTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/FlowResponseStateManagerTests.java
@@ -1,10 +1,14 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.FlowExecutionContext;
@@ -12,7 +16,7 @@ import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockFlowExecutionKey;
 
-public class FlowResponseStateManagerTests extends TestCase {
+public class FlowResponseStateManagerTests {
 
 	private final JSFMockHelper jsfMock = new JSFMockHelper();
 
@@ -24,7 +28,8 @@ public class FlowResponseStateManagerTests extends TestCase {
 	private FlowExecutionContext flowExecutionContext;
 
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 		this.webappContext = new StaticWebApplicationContext();
 		this.webappContext.setServletContext(this.jsfMock.servletContext());
@@ -36,17 +41,14 @@ public class FlowResponseStateManagerTests extends TestCase {
 		this.responseStateManager = new FlowResponseStateManager(null);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.webappContext.close();
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
 
-	public void testname() {
-
-	}
-
+	@Test
 	public void testWriteFlowSerializedView() throws IOException {
 		EasyMock.expect(this.flowExecutionContext.getKey()).andReturn(new MockFlowExecutionKey("e1s1"));
 		LocalAttributeMap<Object> viewMap = new LocalAttributeMap<>();
@@ -64,6 +66,7 @@ public class FlowResponseStateManagerTests extends TestCase {
 		EasyMock.verify(this.flowExecutionContext, this.requestContext);
 	}
 
+	@Test
 	public void testGetState() {
 		Object state = new Object();
 

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfAjaxHandlerTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfAjaxHandlerTests.java
@@ -1,15 +1,20 @@
 package org.springframework.faces.webflow;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.web.context.support.StaticWebApplicationContext;
 
-public class JsfAjaxHandlerTests extends TestCase {
+public class JsfAjaxHandlerTests {
 
 	private final JSFMockHelper jsfMock = new JSFMockHelper();
 	private JsfAjaxHandler ajaxHandler;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 		StaticWebApplicationContext webappContext = new StaticWebApplicationContext();
 		webappContext.setServletContext(this.jsfMock.servletContext());
@@ -17,10 +22,12 @@ public class JsfAjaxHandlerTests extends TestCase {
 		this.ajaxHandler.setApplicationContext(webappContext);
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 	}
 
+	@Test
 	public void testSendAjaxRedirect() throws Exception {
 		this.ajaxHandler.sendAjaxRedirectInternal("/target", this.jsfMock.request(), this.jsfMock.response(), false);
 		assertTrue(this.jsfMock.contentAsString().matches("<\\?xml version='1.0' encoding='utf-8'\\?>\n<partial-response.*><redirect url=\"/target\"/></partial-response>"));

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfFinalResponseActionTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfFinalResponseActionTests.java
@@ -1,5 +1,8 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,9 +17,10 @@ import javax.faces.event.PhaseId;
 import javax.faces.event.PhaseListener;
 import javax.faces.lifecycle.Lifecycle;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.apache.el.ExpressionFactoryImpl;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.support.FluentParserContext;
@@ -31,7 +35,7 @@ import org.springframework.webflow.execution.View;
 import org.springframework.webflow.expression.el.WebFlowELExpressionParser;
 import org.springframework.webflow.test.MockExternalContext;
 
-public class JsfFinalResponseActionTests extends TestCase {
+public class JsfFinalResponseActionTests {
 
 	private static final String VIEW_ID = "/testView.xhtml";
 
@@ -49,12 +53,13 @@ public class JsfFinalResponseActionTests extends TestCase {
 
 	ExpressionParser parser = new WebFlowELExpressionParser(new ExpressionFactoryImpl());
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		configureJsf();
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
@@ -82,6 +87,7 @@ public class JsfFinalResponseActionTests extends TestCase {
 				new LocalParameterMap(new HashMap<>()));
 	}
 
+	@Test
 	public void testRender() throws Exception {
 
 		UIViewRoot newRoot = new UIViewRoot();

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfFlowHandlerAdapterTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfFlowHandlerAdapterTests.java
@@ -1,9 +1,13 @@
 package org.springframework.faces.webflow;
 
-import junit.framework.TestCase;
-
 import org.springframework.webflow.context.servlet.AjaxHandler;
 import org.springframework.webflow.context.servlet.DefaultAjaxHandler;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.webflow.context.ExternalContext;
@@ -12,11 +16,12 @@ import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.executor.FlowExecutionResult;
 import org.springframework.webflow.executor.FlowExecutor;
 
-public class JsfFlowHandlerAdapterTests extends TestCase {
+public class JsfFlowHandlerAdapterTests {
 
 	private JsfFlowHandlerAdapter handlerAdapter;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		StaticWebApplicationContext context = new StaticWebApplicationContext();
 		context.setServletContext(new MockServletContext());
 		this.handlerAdapter = new JsfFlowHandlerAdapter();
@@ -24,12 +29,14 @@ public class JsfFlowHandlerAdapterTests extends TestCase {
 		this.handlerAdapter.setFlowExecutor(new StubFlowExecutor());
 	}
 
+	@Test
 	public void testAjaxHandlerNotProvided() throws Exception {
 		this.handlerAdapter.afterPropertiesSet();
 		assertNotNull(this.handlerAdapter.getAjaxHandler());
 		assertTrue(this.handlerAdapter.getAjaxHandler() instanceof JsfAjaxHandler);
 	}
 
+	@Test
 	public void testAjaxHandlerProvided() throws Exception {
 		AjaxHandler myAjaxHandler = new DefaultAjaxHandler();
 		this.handlerAdapter.setAjaxHandler(myAjaxHandler);

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfManagedBeanAwareELExpressionParserTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfManagedBeanAwareELExpressionParserTests.java
@@ -1,8 +1,11 @@
 package org.springframework.faces.webflow;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
 
 import org.apache.el.ExpressionFactoryImpl;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.support.FluentParserContext;
@@ -10,7 +13,7 @@ import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class JsfManagedBeanAwareELExpressionParserTests extends TestCase {
+public class JsfManagedBeanAwareELExpressionParserTests {
 
 	JSFMockHelper jsfMock = new JSFMockHelper();
 
@@ -18,19 +21,21 @@ public class JsfManagedBeanAwareELExpressionParserTests extends TestCase {
 
 	ExpressionParser parser;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 		RequestContextHolder.setRequestContext(this.requestContext);
 		this.parser = new JsfManagedBeanAwareELExpressionParser(new ExpressionFactoryImpl());
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testGetJSFBean() {
 		this.jsfMock.externalContext().getRequestMap().put("myJsfBean", new Object());
 		Expression expr = this.parser.parseExpression("myJsfBean", new FluentParserContext().evaluate(RequestContext.class));

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfManagedBeanPropertyAccessorTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfManagedBeanPropertyAccessorTests.java
@@ -15,13 +15,19 @@
  */
 package org.springframework.faces.webflow;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class JsfManagedBeanPropertyAccessorTests extends TestCase {
+public class JsfManagedBeanPropertyAccessorTests {
 
 	JSFMockHelper jsfMock = new JSFMockHelper();
 
@@ -29,31 +35,35 @@ public class JsfManagedBeanPropertyAccessorTests extends TestCase {
 
 	private MockRequestContext requestContext;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		this.jsfMock.setUp();
 		this.requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(this.requestContext);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testCanRead() {
 		this.jsfMock.externalContext().getRequestMap().put("myJsfBean", new Object());
 		assertTrue(this.accessor.canRead(null, null, "myJsfBean"));
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testRead() {
 		Object jsfBean = new Object();
 		this.jsfMock.externalContext().getRequestMap().put("myJsfBean", jsfBean);
 		assertEquals(jsfBean, this.accessor.read(null, null, "myJsfBean").getValue());
 	}
 
+	@Test
 	public void testCanWrite() {
 		assertFalse(this.accessor.canWrite(null, null, "myJsfBean"));
 
@@ -73,6 +83,7 @@ public class JsfManagedBeanPropertyAccessorTests extends TestCase {
 		map.clear();
 	}
 
+	@Test
 	public void testWrite() {
 		Object jsfBean1 = new Object();
 		Object jsfBean2 = new Object();

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfUtilsTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfUtilsTests.java
@@ -19,6 +19,7 @@ import org.apache.myfaces.test.mock.MockFacesContextFactory;
 import org.apache.myfaces.test.mock.MockRenderKitFactory;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycle;
 import org.apache.myfaces.test.mock.lifecycle.MockLifecycleFactory;
+import org.junit.Test;
 
 public class JsfUtilsTests extends AbstractJsfTestCase {
 
@@ -26,6 +27,7 @@ public class JsfUtilsTests extends AbstractJsfTestCase {
 		super(name);
 	}
 
+	@Test
 	public void testBeforeListenersCalledInForwardOrder() {
 		List<OrderVerifyingPhaseListener> list = new ArrayList<>();
 		MockLifecycle lifecycle = new MockLifecycle();
@@ -41,6 +43,7 @@ public class JsfUtilsTests extends AbstractJsfTestCase {
 		assertEquals(listener3, list.get(2));
 	}
 
+	@Test
 	public void testAfterListenersCalledInReverseOrder() {
 		List<OrderVerifyingPhaseListener> list = new ArrayList<>();
 		MockLifecycle lifecycle = new MockLifecycle();
@@ -56,6 +59,7 @@ public class JsfUtilsTests extends AbstractJsfTestCase {
 		assertEquals(listener1, list.get(2));
 	}
 
+	@Test
 	public void testGetFactory() {
 		// Not testing all but at least test the mocked factories
 		assertTrue(JsfUtils.findFactory(ApplicationFactory.class) instanceof MockApplicationFactory);
@@ -64,6 +68,7 @@ public class JsfUtilsTests extends AbstractJsfTestCase {
 		assertTrue(JsfUtils.findFactory(RenderKitFactory.class) instanceof MockRenderKitFactory);
 	}
 
+	@Test
 	public void testGetUnknowFactory() {
 		try {
 			JsfUtils.findFactory(InputStream.class);

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfViewFactoryTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfViewFactoryTests.java
@@ -1,5 +1,12 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,11 +28,12 @@ import javax.faces.event.PostRestoreStateEvent;
 import javax.faces.event.SystemEvent;
 import javax.faces.lifecycle.Lifecycle;
 
-import junit.framework.TestCase;
 import org.apache.el.ExpressionFactoryImpl;
 import org.apache.myfaces.test.mock.MockApplication20;
 import org.easymock.EasyMock;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.support.FluentParserContext;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -43,7 +51,7 @@ import org.springframework.webflow.execution.ViewFactory;
 import org.springframework.webflow.expression.el.WebFlowELExpressionParser;
 import org.springframework.webflow.test.MockExternalContext;
 
-public class JsfViewFactoryTests extends TestCase {
+public class JsfViewFactoryTests {
 
 	private static final String VIEW_ID = "/testView.xhtml";
 
@@ -69,7 +77,8 @@ public class JsfViewFactoryTests extends TestCase {
 
 	private final MockHttpServletResponse response = new MockHttpServletResponse();
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		configureJsf();
 		this.extContext.setNativeContext(this.servletContext);
 		this.extContext.setNativeRequest(this.request);
@@ -81,8 +90,8 @@ public class JsfViewFactoryTests extends TestCase {
 				new LocalParameterMap(new HashMap<>()));
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
@@ -100,6 +109,7 @@ public class JsfViewFactoryTests extends TestCase {
 	/**
 	 * View has not yet been created
 	 */
+	@Test
 	public final void testGetView_Create() {
 
 		this.lifecycle = new NoExecutionLifecycle(this.jsfMock.lifecycle());
@@ -126,6 +136,7 @@ public class JsfViewFactoryTests extends TestCase {
 	/**
 	 * View already exists in view/flash scope and must be restored and the lifecycle executed, no flow event signaled
 	 */
+	@Test
 	public final void testGetView_Restore() {
 
 		this.lifecycle = new NoExecutionLifecycle(this.jsfMock.lifecycle());
@@ -159,6 +170,7 @@ public class JsfViewFactoryTests extends TestCase {
 	/**
 	 * View already exists in view/flash scope and must be restored and the lifecycle executed, no flow event signaled
 	 */
+	@Test
 	@SuppressWarnings({ "deprecation", "unchecked" })
 	public final void testGetView_RestoreWithBindings() {
 
@@ -208,6 +220,7 @@ public class JsfViewFactoryTests extends TestCase {
 	 * Ajax Request - View already exists in view/flash scope and must be restored and the lifecycle executed, no flow
 	 * event signaled
 	 */
+	@Test
 	public final void testGetView_Restore_Ajax() {
 
 		this.lifecycle = new NoExecutionLifecycle(this.jsfMock.lifecycle());
@@ -241,6 +254,7 @@ public class JsfViewFactoryTests extends TestCase {
 	/**
 	 * Third party sets the view root before RESTORE_VIEW
 	 */
+	@Test
 	public final void testGetView_ExternalViewRoot() {
 		this.lifecycle = new NoExecutionLifecycle(this.jsfMock.lifecycle());
 		this.factory = new JsfViewFactory(this.parser.parseExpression(VIEW_ID,
@@ -264,6 +278,7 @@ public class JsfViewFactoryTests extends TestCase {
 		assertTrue("The PostRestoreViewEvent was not seen", newRoot.isPostRestoreStateEventSeen());
 	}
 
+	@Test
 	public void testGetView_ExceptionsOnPostRestoreStateEvent() {
 		this.lifecycle = new NoExecutionLifecycle(this.jsfMock.lifecycle());
 		this.factory = new JsfViewFactory(this.parser.parseExpression(VIEW_ID,

--- a/spring-faces/src/test/java/org/springframework/faces/webflow/JsfViewTests.java
+++ b/spring-faces/src/test/java/org/springframework/faces/webflow/JsfViewTests.java
@@ -1,5 +1,9 @@
 package org.springframework.faces.webflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import javax.faces.FacesException;
@@ -11,10 +15,11 @@ import javax.faces.component.html.HtmlInputText;
 import javax.faces.context.FacesContext;
 import javax.faces.lifecycle.Lifecycle;
 
-import junit.framework.TestCase;
 import org.apache.myfaces.test.mock.MockResponseWriter;
 import org.easymock.EasyMock;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.execution.FlowExecutionContext;
 import org.springframework.webflow.execution.FlowExecutionKey;
@@ -23,7 +28,7 @@ import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockParameterMap;
 
-public class JsfViewTests extends TestCase {
+public class JsfViewTests {
 
 	private static final String VIEW_ID = "testView.xhtml";
 
@@ -59,7 +64,8 @@ public class JsfViewTests extends TestCase {
 		}
 	};
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 
 		this.jsfMock.setUp();
 		this.jsfMock.facesContext().getApplication().setViewHandler(new MockViewHandler());
@@ -89,17 +95,19 @@ public class JsfViewTests extends TestCase {
 		this.view = new JsfView(viewToRender, this.jsfMock.lifecycle(), this.context);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		this.jsfMock.tearDown();
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public final void testSaveState() {
 		EasyMock.replay(this.context, this.flowExecutionContext, this.flowMap, this.flashScope);
 		this.view.saveState();
 	}
 
+	@Test
 	public final void testRender() throws IOException {
 
 		EasyMock.expect(this.flashScope.put(EasyMock.matches(FlowFacesContext.RENDER_RESPONSE_KEY), EasyMock.anyObject()))
@@ -110,6 +118,7 @@ public class JsfViewTests extends TestCase {
 		this.view.render();
 	}
 
+	@Test
 	public final void testRenderException() {
 
 		EasyMock.expect(this.flashScope.put(EasyMock.matches(FlowFacesContext.RENDER_RESPONSE_KEY), EasyMock.anyObject()))
@@ -128,6 +137,7 @@ public class JsfViewTests extends TestCase {
 	/**
 	 * View already exists in view scope and must be restored and the lifecycle executed, no event signaled
 	 */
+	@Test
 	public final void testProcessUserEvent_Restored_NoEvent() {
 
 		EasyMock.expect(this.flashScope.getBoolean(EasyMock.matches(FlowFacesContext.RENDER_RESPONSE_KEY))).andStubReturn(
@@ -153,6 +163,7 @@ public class JsfViewTests extends TestCase {
 	/**
 	 * View already exists in view scope and must be restored and the lifecycle executed, an event is signaled
 	 */
+	@Test
 	public final void testProcessUserEvent_Restored_EventSignaled() {
 
 		EasyMock.expect(this.flashScope.getBoolean(EasyMock.matches(FlowFacesContext.RENDER_RESPONSE_KEY))).andStubReturn(
@@ -176,6 +187,7 @@ public class JsfViewTests extends TestCase {
 		assertTrue("The lifecycle should have been invoked", ((EventSignalingLifecycle) lifecycle).executed);
 	}
 
+	@Test
 	public final void testUserEventQueued_GETRefresh() {
 
 		MockParameterMap requestParameterMap = new MockParameterMap();
@@ -189,6 +201,7 @@ public class JsfViewTests extends TestCase {
 		assertFalse("No user event should be queued", createdView.userEventQueued());
 	}
 
+	@Test
 	public final void testUserEventQueued_FormSubmitted() {
 
 		this.jsfMock.request().addParameter("execution", "e1s1");

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
@@ -63,18 +63,8 @@ public abstract class AbstractExternalizedFlowExecutionTests extends AbstractFlo
 
 	/**
 	 * Constructs a default externalized flow execution test.
-	 * @see #setName(String)
 	 */
 	public AbstractExternalizedFlowExecutionTests() {
-		init();
-	}
-
-	/**
-	 * Constructs an externalized flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractExternalizedFlowExecutionTests(String name) {
-		super(name);
 		init();
 	}
 

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.webflow.test.execution;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.springframework.util.Assert;
 import org.springframework.webflow.context.ExternalContext;
@@ -53,7 +55,7 @@ import org.springframework.webflow.test.MockExternalContext;
  * 
  * @author Keith Donald
  */
-public abstract class AbstractFlowExecutionTests extends TestCase {
+public abstract class AbstractFlowExecutionTests {
 
 	/**
 	 * The factory that will create the flow execution to test.
@@ -69,22 +71,6 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 	 * The outcome that was reached when the flow ends; initially null.
 	 */
 	private FlowExecutionOutcome flowExecutionOutcome;
-
-	/**
-	 * Constructs a default flow execution test.
-	 * @see #setName(String)
-	 */
-	public AbstractFlowExecutionTests() {
-		super();
-	}
-
-	/**
-	 * Constructs a flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractFlowExecutionTests(String name) {
-		super(name);
-	}
 
 	/**
 	 * Gets the factory that will create the flow execution to test. This method will create the factory if it is not

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
@@ -62,18 +62,9 @@ public abstract class AbstractXmlFlowExecutionTests extends AbstractExternalized
 
 	/**
 	 * Constructs a default XML flow execution test.
-	 * @see #setName(String)
 	 */
 	public AbstractXmlFlowExecutionTests() {
 		super();
-	}
-
-	/**
-	 * Constructs an XML flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractXmlFlowExecutionTests(String name) {
-		super(name);
 	}
 
 	protected final FlowBuilder createFlowBuilder(FlowDefinitionResource resource) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/UnitTestTemplate.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/UnitTestTemplate.java
@@ -15,20 +15,24 @@
  */
 package org.springframework.webflow;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Keith likes to have these little cut & paste examples in the source repositories. If only he knew the power of code
  * templates in Eclipse...
  */
-public class UnitTestTemplate extends TestCase {
+public class UnitTestTemplate {
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 	}
 
+	@Test
 	public void testScenario1() {
 	}
 
+	@Test
 	public void testScenario2() {
 	}
 

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/AbstractActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/AbstractActionTests.java
@@ -15,8 +15,13 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.Event;
@@ -26,15 +31,17 @@ import org.springframework.webflow.test.MockRequestContext;
 /**
  * Unit tests for {@link AbstractAction}.
  */
-public class AbstractActionTests extends TestCase {
+public class AbstractActionTests {
 
 	private TestAbstractAction action = new TestAbstractAction();
 
+	@Test
 	public void testInitCallback() throws Exception {
 		action.afterPropertiesSet();
 		assertTrue(action.initialized);
 	}
 
+	@Test
 	public void testInitCallbackWithException() throws Exception {
 		action = new TestAbstractAction() {
 			protected void initAction() {
@@ -49,6 +56,7 @@ public class AbstractActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNormalExecute() throws Exception {
 		action = new TestAbstractAction() {
 			protected Event doExecute(RequestContext context) {
@@ -60,6 +68,7 @@ public class AbstractActionTests extends TestCase {
 		assertTrue(result.getAttributes().size() == 0);
 	}
 
+	@Test
 	public void testExceptionalExecute() throws Exception {
 		try {
 			action.execute(new MockRequestContext());
@@ -69,6 +78,7 @@ public class AbstractActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testPreExecuteShortCircuit() throws Exception {
 		action = new TestAbstractAction() {
 			protected Event doPreExecute(RequestContext context) {
@@ -79,6 +89,7 @@ public class AbstractActionTests extends TestCase {
 		assertEquals("success", result.getId());
 	}
 
+	@Test
 	public void testPostExecuteCalled() throws Exception {
 		testNormalExecute();
 		assertTrue(action.postExecuteCalled);
@@ -102,11 +113,13 @@ public class AbstractActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testSuccess() {
 		Event event = action.success();
 		assertEquals(action.getEventFactorySupport().getSuccessEventId(), event.getId());
 	}
 
+	@Test
 	public void testSuccessResult() {
 		Object o = new Object();
 		Event event = action.success(o);
@@ -114,11 +127,13 @@ public class AbstractActionTests extends TestCase {
 		assertSame(o, event.getAttributes().get(action.getEventFactorySupport().getResultAttributeName()));
 	}
 
+	@Test
 	public void testError() {
 		Event event = action.error();
 		assertEquals(action.getEventFactorySupport().getErrorEventId(), event.getId());
 	}
 
+	@Test
 	public void testErrorException() {
 		IllegalArgumentException e = new IllegalArgumentException("woops");
 		Event event = action.error(e);
@@ -126,37 +141,44 @@ public class AbstractActionTests extends TestCase {
 		assertSame(e, event.getAttributes().get(action.getEventFactorySupport().getExceptionAttributeName()));
 	}
 
+	@Test
 	public void testYes() {
 		Event event = action.yes();
 		assertEquals(action.getEventFactorySupport().getYesEventId(), event.getId());
 	}
 
+	@Test
 	public void testNo() {
 		Event event = action.no();
 		assertEquals(action.getEventFactorySupport().getNoEventId(), event.getId());
 	}
 
+	@Test
 	public void testTrueResult() {
 		Event event = action.result(true);
 		assertEquals(action.getEventFactorySupport().getYesEventId(), event.getId());
 	}
 
+	@Test
 	public void testFalseResult() {
 		Event event = action.result(false);
 		assertEquals(action.getEventFactorySupport().getNoEventId(), event.getId());
 	}
 
+	@Test
 	public void testCustomResult() {
 		Event event = action.result("custom");
 		assertEquals("custom", event.getId());
 	}
 
+	@Test
 	public void testCustomResultObject() {
 		Event event = action.result("custom", "result", "value");
 		assertEquals("custom", event.getId());
 		assertEquals("value", event.getAttributes().getString("result"));
 	}
 
+	@Test
 	public void testCustomResultCollection() {
 		LocalAttributeMap<Object> collection = new LocalAttributeMap<>();
 		collection.put("result", "value");

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/CompositeActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/CompositeActionTests.java
@@ -15,9 +15,11 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
 import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.execution.Event;
@@ -29,19 +31,20 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Ulrik Sandberg
  */
-public class CompositeActionTests extends TestCase {
+public class CompositeActionTests {
 
 	private CompositeAction tested;
 
 	private Action actionMock;
 
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		actionMock = EasyMock.createMock(Action.class);
 		Action[] actions = new Action[] { actionMock };
 		tested = new CompositeAction(actions);
 	}
 
+	@Test
 	public void testDoExecute() throws Exception {
 		MockRequestContext mockRequestContext = new MockRequestContext();
 		LocalAttributeMap<Object> attributes = new LocalAttributeMap<>();
@@ -54,6 +57,7 @@ public class CompositeActionTests extends TestCase {
 		assertEquals(1, result.getAttributes().size());
 	}
 
+	@Test
 	public void testDoExecuteWithError() throws Exception {
 		tested.setStopOnError(true);
 		MockRequestContext mockRequestContext = new MockRequestContext();
@@ -64,6 +68,7 @@ public class CompositeActionTests extends TestCase {
 		assertEquals("error", result.getId());
 	}
 
+	@Test
 	public void testDoExecuteWithNullResult() throws Exception {
 		tested.setStopOnError(true);
 		MockRequestContext mockRequestContext = new MockRequestContext();
@@ -74,6 +79,7 @@ public class CompositeActionTests extends TestCase {
 		assertEquals("Expecting success since no check is performed if null result,", "success", result.getId());
 	}
 
+	@Test
 	public void testMultipleActions() throws Exception {
 		CompositeAction ca = new CompositeAction(
 				new Action() {

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/DispatchMethodInvokerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/DispatchMethodInvokerTests.java
@@ -15,34 +15,43 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-public class DispatchMethodInvokerTests extends TestCase {
+import org.junit.Before;
+import org.junit.Test;
+
+public class DispatchMethodInvokerTests {
 
 	private MockClass mockClass;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		mockClass = new MockClass();
 	}
 
+	@Test
 	public void testInvokeWithExplicitParameters() throws Exception {
 		DispatchMethodInvoker invoker = new DispatchMethodInvoker(mockClass, Object.class);
 		invoker.invoke("argumentMethod", "testValue");
 		assertTrue("Method should have been called successfully", mockClass.getMethodCalled());
 	}
 
+	@Test
 	public void testInvokeWithAssignableParameters() throws Exception {
 		DispatchMethodInvoker invoker = new DispatchMethodInvoker(mockClass, String.class);
 		invoker.invoke("argumentMethod", "testValue");
 		assertTrue("Method should have been called successfully", mockClass.getMethodCalled());
 	}
 
+	@Test
 	public void testInvokeWithNoParameters() throws Exception {
 		DispatchMethodInvoker invoker = new DispatchMethodInvoker(mockClass);
 		invoker.invoke("noArgumentMethod");
 		assertTrue("Method should have been called successfully", mockClass.getMethodCalled());
 	}
 
+	@Test
 	public void testInvokeWithException() {
 		DispatchMethodInvoker invoker = new DispatchMethodInvoker(mockClass, Object.class);
 		try {

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/EvaluateActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/EvaluateActionTests.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
@@ -25,8 +26,9 @@ import org.springframework.webflow.test.MockRequestContext;
  * Unit tests for {@link EvaluateAction}.
  * @author Jeremy Grelle
  */
-public class EvaluateActionTests extends TestCase {
+public class EvaluateActionTests {
 
+	@Test
 	public void testEvaluateExpressionNoResultExposer() throws Exception {
 		EvaluateAction action = new EvaluateAction(new StaticExpression("bar"), null);
 		MockRequestContext context = new MockRequestContext();
@@ -34,6 +36,7 @@ public class EvaluateActionTests extends TestCase {
 		assertEquals("bar", result.getId());
 	}
 
+	@Test
 	public void testEvaluateExpressionEmptyStringResult() throws Exception {
 		EvaluateAction action = new EvaluateAction(new StaticExpression(""), null);
 		MockRequestContext context = new MockRequestContext();
@@ -41,6 +44,7 @@ public class EvaluateActionTests extends TestCase {
 		assertEquals("null", result.getId());
 	}
 
+	@Test
 	public void testEvaluateExpressionNullResult() throws Exception {
 		EvaluateAction action = new EvaluateAction(new StaticExpression(null), null);
 		MockRequestContext context = new MockRequestContext();
@@ -48,6 +52,7 @@ public class EvaluateActionTests extends TestCase {
 		assertEquals("success", result.getId());
 	}
 
+	@Test
 	public void testEvaluateExpressionResultExposer() throws Exception {
 		StaticExpression resultExpression = new StaticExpression("");
 		EvaluateAction action = new EvaluateAction(new StaticExpression("bar"), resultExpression);

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/EventFactorySupportTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/EventFactorySupportTests.java
@@ -15,28 +15,34 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.execution.Event;
 
 /**
  * Unit tests for {@link EventFactorySupport}.
  */
-public class EventFactorySupportTests extends TestCase {
+public class EventFactorySupportTests {
 
 	private EventFactorySupport support = new EventFactorySupport();
 
 	private Object source = new Object();
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 	}
 
+	@Test
 	public void testSuccess() {
 		Event e = support.success(source);
 		assertEquals("success", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testSuccessWithResult() {
 		Object result = new Object();
 		Event e = support.success(source, result);
@@ -45,12 +51,14 @@ public class EventFactorySupportTests extends TestCase {
 		assertSame(result, e.getAttributes().get("result"));
 	}
 
+	@Test
 	public void testError() {
 		Event e = support.error(source);
 		assertEquals("error", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testErrorWithException() {
 		Exception ex = new Exception();
 		Event e = support.error(source, ex);
@@ -59,36 +67,42 @@ public class EventFactorySupportTests extends TestCase {
 		assertSame(ex, e.getAttributes().get("exception"));
 	}
 
+	@Test
 	public void testYes() {
 		Event e = support.yes(source);
 		assertEquals("yes", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testNo() {
 		Event e = support.no(source);
 		assertEquals("no", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testBooleanTrueEvent() {
 		Event e = support.event(source, true);
 		assertEquals("yes", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testBooleanFalseEvent() {
 		Event e = support.event(source, false);
 		assertEquals("no", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testEvent() {
 		Event e = support.event(source, "no");
 		assertEquals("no", e.getId());
 		assertSame(source, e.getSource());
 	}
 
+	@Test
 	public void testEventWithAttrs() {
 		Event e = support.event(source, "no", "foo", "bar");
 		assertEquals("no", e.getId());

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/ExternalRedirectActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/ExternalRedirectActionTests.java
@@ -1,13 +1,16 @@
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ExternalRedirectActionTests extends TestCase {
+public class ExternalRedirectActionTests {
 	private ExternalRedirectAction action;
 
+	@Test
 	public void testExecute() throws Exception {
 		action = new ExternalRedirectAction(new StaticExpression("/wherever"));
 		MockRequestContext context = new MockRequestContext();
@@ -15,6 +18,7 @@ public class ExternalRedirectActionTests extends TestCase {
 		assertEquals("/wherever", context.getMockExternalContext().getExternalRedirectUrl());
 	}
 
+	@Test
 	public void testExecuteWithNullResourceUri() {
 		try {
 			action = new ExternalRedirectAction(null);

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/FlowDefinitionRedirectActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/FlowDefinitionRedirectActionTests.java
@@ -1,14 +1,17 @@
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class FlowDefinitionRedirectActionTests extends TestCase {
+public class FlowDefinitionRedirectActionTests {
 	private FlowDefinitionRedirectAction action;
 
+	@Test
 	public void testExecute() throws Exception {
 		Expression flowId = new StaticExpression("user?foo=bar");
 		action = new FlowDefinitionRedirectAction(flowId);
@@ -18,6 +21,7 @@ public class FlowDefinitionRedirectActionTests extends TestCase {
 		assertEquals("bar", context.getMockExternalContext().getFlowRedirectFlowInput().get("foo"));
 	}
 
+	@Test
 	public void testExecuteWithNullRequestFields() throws Exception {
 		Expression flowId = new StaticExpression("user");
 		action = new FlowDefinitionRedirectAction(flowId);
@@ -26,6 +30,7 @@ public class FlowDefinitionRedirectActionTests extends TestCase {
 		assertEquals("user", context.getMockExternalContext().getFlowRedirectFlowId());
 	}
 
+	@Test
 	public void testExecuteWithNullFlowId() throws Exception {
 		try {
 			action = new FlowDefinitionRedirectAction(null);

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/FormActionBindingTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/FormActionBindingTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -32,7 +35,7 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Erwin Vervaet
  */
-public class FormActionBindingTests extends TestCase {
+public class FormActionBindingTests {
 
 	public static class TestBean {
 
@@ -48,6 +51,7 @@ public class FormActionBindingTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testMessageCodesOnBindFailure() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setPathInfo("/fooFlow");
@@ -72,6 +76,7 @@ public class FormActionBindingTests extends TestCase {
 		assertEquals(1, formActionErrors.getFieldErrorCount("prop"));
 	}
 
+	@Test
 	public void testFieldBinding() throws Exception {
 		FormAction formAction = new FormAction() {
 			protected Object createFormObject(RequestContext context) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/FormActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/FormActionTests.java
@@ -15,8 +15,16 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
@@ -35,7 +43,7 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Erwin Vervaet
  */
-public class FormActionTests extends TestCase {
+public class FormActionTests {
 
 	private static class TestBean {
 
@@ -80,10 +88,12 @@ public class FormActionTests extends TestCase {
 
 	private FormAction action;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		action = createFormAction("test");
 	}
 
+	@Test
 	public void testSetupForm() throws Exception {
 		MockRequestContext context = new MockRequestContext();
 
@@ -111,6 +121,7 @@ public class FormActionTests extends TestCase {
 		return map;
 	}
 
+	@Test
 	public void testSetupFormWithExistingFormObject() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -135,6 +146,7 @@ public class FormActionTests extends TestCase {
 		assertEquals("bla", getFormObject(context).getProp());
 	}
 
+	@Test
 	public void testBindAndValidate() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -150,6 +162,7 @@ public class FormActionTests extends TestCase {
 		assertEquals("value", getFormObject(context).getProp());
 	}
 
+	@Test
 	public void testBindAndValidateFailure() throws Exception {
 		MockRequestContext context = new MockRequestContext();
 
@@ -165,6 +178,7 @@ public class FormActionTests extends TestCase {
 		assertNull(getFormObject(context).getProp());
 	}
 
+	@Test
 	public void testBindAndValidateWithExistingFormObject() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -189,6 +203,7 @@ public class FormActionTests extends TestCase {
 	}
 
 	// this is what happens in a 'form state'
+	@Test
 	public void testBindAndValidateFailureThenSetupForm() throws Exception {
 		MockRequestContext context = new MockRequestContext(blankParameters());
 
@@ -221,6 +236,7 @@ public class FormActionTests extends TestCase {
 		assertEquals("", getFormObject(context).getProp());
 	}
 
+	@Test
 	public void testMultipleFormObjectsInOneFlow() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -263,6 +279,7 @@ public class FormActionTests extends TestCase {
 		assertEquals("", getFormObject(context, "otherTest").getProp());
 	}
 
+	@Test
 	public void testGetFormObject() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 		FormAction action = createFormAction("test");
@@ -276,6 +293,7 @@ public class FormActionTests extends TestCase {
 		assertSame(formObject, testBean);
 	}
 
+	@Test
 	public void testGetFormErrors() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 		FormAction action = createFormAction("test");
@@ -290,6 +308,7 @@ public class FormActionTests extends TestCase {
 		assertSame(errors, testErrors);
 	}
 
+	@Test
 	public void testFormObjectAccessUsingAlias() throws Exception {
 		MockRequestContext context = new MockRequestContext(blankParameters());
 
@@ -319,6 +338,7 @@ public class FormActionTests extends TestCase {
 	}
 
 	// as reported in SWF-4
+	@Test
 	public void testInconsistentFormObjectAndErrors() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -353,6 +373,7 @@ public class FormActionTests extends TestCase {
 		assertSame(formObject, errors.getTarget());
 	}
 
+	@Test
 	public void testMultipleFormObjects() throws Exception {
 		MockRequestContext context = new MockRequestContext(parameters());
 
@@ -387,6 +408,7 @@ public class FormActionTests extends TestCase {
 		assertSame(test2, new FormObjectAccessor(context).getCurrentFormObject());
 	}
 
+	@Test
 	public void testFormObjectAndNoErrors() throws Exception {
 		// this typically happens with mapping from parent flow to subflow
 		MockRequestContext context = new MockRequestContext(parameters());
@@ -408,6 +430,7 @@ public class FormActionTests extends TestCase {
 		assertFalse(getErrors(context).hasErrors());
 	}
 
+	@Test
 	public void testSetupFormThenBindAndValidate() throws Exception {
 		FormAction action = createFormAction("testBean");
 		MockRequestContext context = new MockRequestContext();
@@ -424,6 +447,7 @@ public class FormActionTests extends TestCase {
 		assertEquals(true, ((TestBeanValidator) action.getValidator()).invoked);
 	}
 
+	@Test
 	public void testFormActionWithValidatorAndNoFormActionClass() throws Exception {
 		FormAction action = new FormAction() {
 			protected Object createFormObject(RequestContext context) throws Exception {

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/MultiActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/MultiActionTests.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.webflow.action.DispatchMethodInvoker.MethodLookupException;
 import org.springframework.webflow.action.MultiAction.MethodResolver;
 import org.springframework.webflow.engine.StubViewFactory;
@@ -28,18 +30,20 @@ import org.springframework.webflow.test.MockRequestContext;
 /**
  * Unit tests for {@link MultiAction}.
  */
-public class MultiActionTests extends TestCase {
+public class MultiActionTests {
 
 	private TestMultiAction action = new TestMultiAction();
 
 	private MockRequestContext context = new MockRequestContext();
 
+	@Test
 	public void testDispatchWithMethodSignature() throws Exception {
 		context.getAttributeMap().put(AnnotatedAction.METHOD_ATTRIBUTE, "increment");
 		action.execute(context);
 		assertEquals(1, action.counter);
 	}
 
+	@Test
 	public void testDispatchWithBogusMethodSignature() throws Exception {
 		context.getAttributeMap().put(AnnotatedAction.METHOD_ATTRIBUTE, "bogus");
 		try {
@@ -50,6 +54,7 @@ public class MultiActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDispatchWithCurrentStateId() throws Exception {
 		MockFlowSession session = context.getMockFlowExecutionContext().getMockActiveSession();
 		session.setState(new ViewState(session.getDefinitionInternal(), "increment", new StubViewFactory()));
@@ -57,6 +62,7 @@ public class MultiActionTests extends TestCase {
 		assertEquals(1, action.counter);
 	}
 
+	@Test
 	public void testNoSuchMethodWithCurrentStateId() throws Exception {
 		try {
 			action.execute(context);
@@ -66,6 +72,7 @@ public class MultiActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCannotResolveMethod() throws Exception {
 		try {
 			context.getMockFlowExecutionContext().getMockActiveSession().setState(null);
@@ -76,6 +83,7 @@ public class MultiActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCustomMethodResolver() throws Exception {
 		MethodResolver methodResolver = context -> "increment";
 		action.setMethodResolver(methodResolver);

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/RenderActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/RenderActionTests.java
@@ -1,14 +1,17 @@
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.execution.View;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class RenderActionTests extends TestCase {
+public class RenderActionTests {
+	@Test
 	public void testRenderAction() throws Exception {
 		StaticExpression name = new StaticExpression("frag1");
 		StaticExpression name2 = new StaticExpression("frag2");
@@ -21,6 +24,7 @@ public class RenderActionTests extends TestCase {
 		assertEquals("frag2", fragments[1]);
 	}
 
+	@Test
 	public void testIllegalNullArg() {
 		try {
 			new RenderAction((Expression[]) null);
@@ -30,6 +34,7 @@ public class RenderActionTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testIllegalEmptyArg() {
 		try {
 			new RenderAction();

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/ResultObjectBasedEventFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/ResultObjectBasedEventFactoryTests.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.webflow.action;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
 import java.util.Date;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
@@ -27,15 +30,17 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Erwin Vervaet
  */
-public class ResultObjectBasedEventFactoryTests extends TestCase {
+public class ResultObjectBasedEventFactoryTests {
 
 	private ResultObjectBasedEventFactory factory = new ResultObjectBasedEventFactory();
 
+	@Test
 	public void testNull() {
 		Event event = factory.createResultEvent(this, null, new MockRequestContext());
 		assertEquals(factory.getNullEventId(), event.getId());
 	}
 
+	@Test
 	public void testBoolean() {
 		Event event = factory.createResultEvent(this, true, new MockRequestContext());
 		assertEquals(factory.getYesEventId(), event.getId());
@@ -43,6 +48,7 @@ public class ResultObjectBasedEventFactoryTests extends TestCase {
 		assertEquals(factory.getNoEventId(), event.getId());
 	}
 
+	@Test
 	public void testLabeledEnum() {
 		Event event = factory.createResultEvent(this, MyLabeledEnum.A, new MockRequestContext());
 		assertEquals("A", event.getId());
@@ -62,17 +68,20 @@ public class ResultObjectBasedEventFactoryTests extends TestCase {
 	 * public String toString() { return "MyEnum " + name(); } }
 	 */
 
+	@Test
 	public void testString() {
 		Event event = factory.createResultEvent(this, "foobar", new MockRequestContext());
 		assertEquals("foobar", event.getId());
 	}
 
+	@Test
 	public void testEvent() {
 		Event orig = new Event(this, "test");
 		Event event = factory.createResultEvent(this, orig, new MockRequestContext());
 		assertSame(orig, event);
 	}
 
+	@Test
 	public void testUnsupported() {
 		try {
 			factory.createResultEvent(this, new Date(), new MockRequestContext());

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/ResultObjectEventFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/ResultObjectEventFactoryTests.java
@@ -15,26 +15,32 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
 /**
  * Unit tests for {@link ResultObjectBasedEventFactory}.
  */
-public class ResultObjectEventFactoryTests extends TestCase {
+public class ResultObjectEventFactoryTests {
 
 	private MockRequestContext context = new MockRequestContext();
 
 	private ResultObjectBasedEventFactory factory = new ResultObjectBasedEventFactory();
 
+	@Test
 	public void testAlreadyAnEvent() {
 		Event event = new Event(this, "event");
 		Event result = factory.createResultEvent(this, event, context);
 		assertSame(event, result);
 	}
 
+	@Test
 	public void testMappedTypes() {
 		assertTrue(factory.isMappedValueType(MyEnum.class));
 		assertTrue(factory.isMappedValueType(boolean.class));
@@ -43,11 +49,13 @@ public class ResultObjectEventFactoryTests extends TestCase {
 		assertFalse(factory.isMappedValueType(Integer.class));
 	}
 
+	@Test
 	public void testNullResult() {
 		Event result = factory.createResultEvent(this, null, context);
 		assertEquals("null", result.getId());
 	}
 
+	@Test
 	public void testBooleanResult() {
 		Event result = factory.createResultEvent(this, true, context);
 		assertEquals("yes", result.getId());
@@ -55,11 +63,13 @@ public class ResultObjectEventFactoryTests extends TestCase {
 		assertEquals("no", result.getId());
 	}
 
+	@Test
 	public void testLabeledEnumResult() {
 		Event result = factory.createResultEvent(this, MyEnum.FOO, context);
 		assertEquals("FOO", result.getId());
 	}
 
+	@Test
 	public void testOtherResult() {
 		Event result = factory.createResultEvent(this, "hello", context);
 		assertEquals("hello", result.getId());

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/SetActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/SetActionTests.java
@@ -1,13 +1,15 @@
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class SetActionTests extends TestCase {
+public class SetActionTests {
 
+	@Test
 	public void testSetAction() throws Exception {
 		StaticExpression name = new StaticExpression("");
 		SetAction action = new SetAction(name, new StaticExpression("bar"));

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/SuccessEventFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/SuccessEventFactoryTests.java
@@ -15,20 +15,22 @@
  */
 package org.springframework.webflow.action;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.Event;
 import org.springframework.webflow.test.MockRequestContext;
 
 /**
  * Unit tests for {@link SuccessEventFactory}.
  */
-public class SuccessEventFactoryTests extends TestCase {
+public class SuccessEventFactoryTests {
 
 	private MockRequestContext context = new MockRequestContext();
 
 	private SuccessEventFactory factory = new SuccessEventFactory();
 
+	@Test
 	public void testDefaultAdaptionRules() {
 		Event result = factory.createResultEvent(this, "result", context);
 		assertEquals("success", result.getId());

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowBuilderServicesConfigurationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowBuilderServicesConfigurationTests.java
@@ -1,9 +1,14 @@
 package org.springframework.webflow.config;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Set;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionException;
 import org.springframework.binding.convert.ConversionExecutionException;
 import org.springframework.binding.convert.ConversionExecutor;
@@ -22,18 +27,20 @@ import org.springframework.webflow.execution.ViewFactory;
 import org.springframework.webflow.mvc.builder.MvcViewFactoryCreator;
 import org.springframework.webflow.validation.ValidationHintResolver;
 
-public abstract class AbstractFlowBuilderServicesConfigurationTests extends TestCase {
+public abstract class AbstractFlowBuilderServicesConfigurationTests {
 
 	protected ApplicationContext context;
 
 	protected FlowBuilderServices builderServices;
 
+	@Before
 	public void setUp() {
 		context = initApplicationContext();
 	}
 
 	protected abstract ApplicationContext initApplicationContext();
 
+	@Test
 	public void testFlowBuilderServicesDefaultConfig() {
 		builderServices = (FlowBuilderServices) context.getBean("flowBuilderServicesDefault");
 		assertNotNull(builderServices);
@@ -44,6 +51,7 @@ public abstract class AbstractFlowBuilderServicesConfigurationTests extends Test
 		assertFalse(builderServices.getDevelopment());
 	}
 
+	@Test
 	public void testFlowBuilderServicesAllCustomized() {
 		builderServices = (FlowBuilderServices) context.getBean("flowBuilderServicesAllCustom");
 		assertNotNull(builderServices);
@@ -55,6 +63,7 @@ public abstract class AbstractFlowBuilderServicesConfigurationTests extends Test
 		assertTrue(builderServices.getDevelopment());
 	}
 
+	@Test
 	public void testFlowBuilderServicesConversionServiceCustomized() {
 		builderServices = (FlowBuilderServices) context.getBean("flowBuilderServicesConversionServiceCustom");
 		assertNotNull(builderServices);

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowExecutorConfigurationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowExecutorConfigurationTests.java
@@ -1,7 +1,10 @@
 package org.springframework.webflow.config;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.webflow.conversation.Conversation;
 import org.springframework.webflow.conversation.ConversationException;
@@ -16,10 +19,11 @@ import org.springframework.webflow.executor.FlowExecutor;
 import org.springframework.webflow.executor.FlowExecutorImpl;
 import org.springframework.webflow.test.MockExternalContext;
 
-public abstract class AbstractFlowExecutorConfigurationTests extends TestCase {
+public abstract class AbstractFlowExecutorConfigurationTests {
 
 	private ApplicationContext context;
 
+	@Before
 	public void setUp() {
 		context = initApplicationContext();
 	}
@@ -27,6 +31,7 @@ public abstract class AbstractFlowExecutorConfigurationTests extends TestCase {
 	protected abstract ApplicationContext initApplicationContext();
 
 
+	@Test
 	public void testConfigOk() {
 		FlowExecutor executor = context.getBean("flowExecutor", FlowExecutor.class);
 		executor.launchExecution("flow", null, new MockExternalContext());
@@ -34,6 +39,7 @@ public abstract class AbstractFlowExecutorConfigurationTests extends TestCase {
 		executor2.launchExecution("flow", null, new MockExternalContext());
 	}
 
+	@Test
 	public void testCustomConversationManager() {
 		FlowExecutorImpl executor = context.getBean("flowExecutor", FlowExecutorImpl.class);
 		try {

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowRegistryConfigurationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/AbstractFlowRegistryConfigurationTests.java
@@ -1,19 +1,24 @@
 package org.springframework.webflow.config;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.webflow.definition.FlowDefinition;
 import org.springframework.webflow.definition.registry.FlowDefinitionConstructionException;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.definition.registry.NoSuchFlowDefinitionException;
 
-public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
+public abstract class AbstractFlowRegistryConfigurationTests {
 
 	protected ApplicationContext context;
 
 	protected FlowDefinitionRegistry registry;
 
+	@Before
 	public void setUp() {
 		this.context = initApplicationContext();
 		this.registry = (FlowDefinitionRegistry) context.getBean("flowRegistry");
@@ -22,6 +27,7 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 	protected abstract ApplicationContext initApplicationContext();
 
 
+	@Test
 	public void testRegistryFlowLocationsPopulated() {
 		FlowDefinition flow = registry.getFlowDefinition("flow");
 		assertEquals("flow", flow.getId());
@@ -29,6 +35,7 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 		assertEquals(2, flow.getAttributes().get("bar"));
 	}
 
+	@Test
 	public void testRegistryFlowLocationPatternsPopulated() {
 		FlowDefinition flow1 = registry.getFlowDefinition("flow1");
 		assertEquals("flow1", flow1.getId());
@@ -36,16 +43,19 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 		assertEquals("flow2", flow2.getId());
 	}
 
+	@Test
 	public void testRegistryFlowBuildersPopulated() {
 		FlowDefinition foo = registry.getFlowDefinition("foo");
 		assertEquals("foo", foo.getId());
 	}
 
+	@Test
 	public void testRegistryFlowBuildersPopulatedWithId() {
 		FlowDefinition foo = registry.getFlowDefinition("foo2");
 		assertEquals("foo2", foo.getId());
 	}
 
+	@Test
 	public void testRegistryFlowBuildersPopulatedWithAttributes() {
 		FlowDefinition foo3 = registry.getFlowDefinition("foo3");
 		assertEquals("foo3", foo3.getId());
@@ -53,6 +63,7 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 		assertEquals(2, foo3.getAttributes().get("bar"));
 	}
 
+	@Test
 	public void testNoSuchFlow() {
 		try {
 			registry.getFlowDefinition("not there");
@@ -61,6 +72,7 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBogusPath() {
 		try {
 			registry.getFlowDefinition("bogus");
@@ -69,6 +81,7 @@ public abstract class AbstractFlowRegistryConfigurationTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParent() {
 		assertNotNull(registry.getParent());
 		assertEquals("parentFlow", registry.getParent().getFlowDefinition("parentFlow").getId());

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/FlowDefinitionResourceFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/FlowDefinitionResourceFactoryTests.java
@@ -15,10 +15,12 @@
  */
 package org.springframework.webflow.config;
 
+import static org.junit.Assert.assertEquals;
+
 import java.net.MalformedURLException;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -30,76 +32,88 @@ import org.springframework.web.context.support.ServletContextResourceLoader;
 /**
  * Unit tests for {@link FlowDefinitionResourceFactory}.
  */
-public class FlowDefinitionResourceFactoryTests extends TestCase {
+public class FlowDefinitionResourceFactoryTests {
 
 	private ResourceLoader resourceLoader;
 
 	private FlowDefinitionResourceFactory factory;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		resourceLoader = new ServletContextResourceLoader(new MockServletContext());
 		factory = new FlowDefinitionResourceFactory();
 	}
 
+	@Test
 	public void testGetFlowIdNoBasePath() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		assertEquals("booking-flow", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdFileSystemResourceBasePathMatch() {
 		Resource resource = new FileSystemResource("/the/path/on/the/file/system/sample-flow.xml");
 		factory.setBasePath("file:/the/path");
 		assertEquals("on/the/file/system", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdCustomBasePath() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("WEB-INF");
 		assertEquals("hotels/booking", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowCustomBasePathTrailingSlash() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("WEB-INF/");
 		assertEquals("hotels/booking", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdCustomBasePathLeadingSlash() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("/WEB-INF");
 		assertEquals("hotels/booking", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdCustomBasePathLeadingAndTrailingSlash() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("/WEB-INF/");
 		assertEquals("hotels/booking", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdFlowPathIsBasePath() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("/WEB-INF/hotels/booking");
 		assertEquals("booking-flow", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdBasePathMismatch() {
 		Resource resource = resourceLoader.getResource("/WEB-INF/hotels/booking/booking-flow.xml");
 		factory.setBasePath("/foo/bar");
 		assertEquals("WEB-INF/hotels/booking", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdClassPathResource() {
 		Resource resource = new ClassPathResource("org/springframework/webflow/sample/sample-flow.xml");
 		factory.setBasePath("classpath:org/springframework/webflow/");
 		assertEquals("sample", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdClassPathStarResource() {
 		Resource resource = new ClassPathResource("org/springframework/webflow/sample/sample-flow.xml");
 		factory.setBasePath("classpath*:org/springframework/webflow/");
 		assertEquals("sample", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdFileSystemResource() {
 		Resource resource = new FileSystemResource(
 				"/the/path/on/the/file/system/org/springframework/webflow/sample/sample-flow.xml");
@@ -107,12 +121,14 @@ public class FlowDefinitionResourceFactoryTests extends TestCase {
 		assertEquals("sample", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdFileSystemResourceNoBasePathMatch() {
 		Resource resource = new FileSystemResource("/the/path/on/the/file/system/sample-flow.xml");
 		factory.setBasePath("classpath:org/springframework/webflow/");
 		assertEquals("the/path/on/the/file/system", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdUrlResource() throws MalformedURLException {
 		Resource resource = new UrlResource(
 				"file:/the/path/on/the/file/system/org/springframework/webflow/sample/sample-flow.xml");
@@ -120,6 +136,7 @@ public class FlowDefinitionResourceFactoryTests extends TestCase {
 		assertEquals("sample", factory.getFlowId(resource));
 	}
 
+	@Test
 	public void testGetFlowIdUrlResourceNoBasePathMatch() throws MalformedURLException {
 		Resource resource = new UrlResource("file:/the/path/on/the/file/system/sample-flow.xml");
 		factory.setBasePath("classpath:org/springframework/webflow/");

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/FlowExecutorFactoryBeanTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/FlowExecutorFactoryBeanTests.java
@@ -3,12 +3,8 @@ package org.springframework.webflow.config;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
-import org.springframework.webflow.definition.FlowDefinition;
-import org.springframework.webflow.definition.registry.FlowDefinitionConstructionException;
-import org.springframework.webflow.definition.registry.FlowDefinitionLocator;
-import org.springframework.webflow.definition.registry.NoSuchFlowDefinitionException;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.engine.EndState;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.StubViewFactory;
@@ -18,13 +14,15 @@ import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 import org.springframework.webflow.execution.FlowExecutionListener;
 import org.springframework.webflow.execution.factory.StaticFlowExecutionListenerLoader;
 
-public class FlowExecutorFactoryBeanTests extends TestCase {
+public class FlowExecutorFactoryBeanTests {
 	private FlowExecutorFactoryBean factoryBean;
 
+	@Before
 	public void setUp() {
 		factoryBean = new FlowExecutorFactoryBean();
 	}
 
+	@Test
 	public void testGetFlowExecutorNoPropertiesSet() throws Exception {
 		try {
 			factoryBean.afterPropertiesSet();
@@ -33,6 +31,7 @@ public class FlowExecutorFactoryBeanTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetFlowExecutorBasicConfig() throws Exception {
 		factoryBean.setFlowDefinitionLocator(id -> {
 			Flow flow = new Flow(id);
@@ -45,6 +44,7 @@ public class FlowExecutorFactoryBeanTests extends TestCase {
 		factoryBean.getObject();
 	}
 
+	@Test
 	public void testGetFlowExecutorOptionsSpecified() throws Exception {
 		factoryBean.setFlowDefinitionLocator(id -> {
 			Flow flow = new Flow(id);

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/FlowRegistryBeanDefinitionParserTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/FlowRegistryBeanDefinitionParserTests.java
@@ -1,7 +1,12 @@
 package org.springframework.webflow.config;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Map;
 
+import org.junit.Test;
 import org.springframework.binding.convert.service.DefaultConversionService;
 import org.springframework.binding.expression.spel.SpringELExpressionParser;
 import org.springframework.context.ApplicationContext;
@@ -15,6 +20,7 @@ public class FlowRegistryBeanDefinitionParserTests extends AbstractFlowRegistryC
 		return new ClassPathXmlApplicationContext("org/springframework/webflow/config/flow-registry.xml");
 	}
 
+	@Test
 	public void testDefaultFlowBuilderServices() {
 		Map<String, FlowBuilderServices> flowBuilderServicesBeans = context.getBeansOfType(FlowBuilderServices.class);
 		assertTrue(flowBuilderServicesBeans.size() > 0);

--- a/spring-webflow/src/test/java/org/springframework/webflow/config/FlowRegistryFactoryBeanTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/config/FlowRegistryFactoryBeanTests.java
@@ -1,24 +1,32 @@
 package org.springframework.webflow.config;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashSet;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.definition.FlowDefinition;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
 import org.springframework.webflow.test.TestFlowBuilderServicesFactory;
 
-public class FlowRegistryFactoryBeanTests extends TestCase {
+public class FlowRegistryFactoryBeanTests {
 	private FlowRegistryFactoryBean factoryBean;
 
+	@Before
 	public void setUp() {
 		factoryBean = new FlowRegistryFactoryBean();
 	}
 
+	@After
 	public void tearDown() throws Exception {
 		factoryBean.destroy();
 	}
 
+	@Test
 	public void testGetFlowRegistry() throws Exception {
 		HashSet<FlowElementAttribute> attributes = new HashSet<>();
 		attributes.add(new FlowElementAttribute("foo", "bar", null));
@@ -40,6 +48,7 @@ public class FlowRegistryFactoryBeanTests extends TestCase {
 		assertEquals("flow2", def.getId());
 	}
 
+	@Test
 	public void testGetFlowRegistryGeneratedFlowId() throws Exception {
 		FlowLocation location1 = new FlowLocation(null, "org/springframework/webflow/config/flow.xml", null);
 		FlowLocation[] flowLocations = new FlowLocation[] { location1 };
@@ -53,6 +62,7 @@ public class FlowRegistryFactoryBeanTests extends TestCase {
 		assertTrue(def.getAttributes().isEmpty());
 	}
 
+	@Test
 	public void testGetFlowRegistryCustomFlowServices() throws Exception {
 		FlowLocation location1 = new FlowLocation(null, "org/springframework/webflow/config/flow.xml", null);
 		FlowLocation[] flowLocations = new FlowLocation[] { location1 };

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/AbstractAjaxHandlerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/AbstractAjaxHandlerTests.java
@@ -1,51 +1,60 @@
 package org.springframework.webflow.context.servlet;
 
-import java.io.IOException;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-public class AbstractAjaxHandlerTests extends TestCase {
+public class AbstractAjaxHandlerTests {
 
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 	}
 
+	@Test
 	public void testIsAjaxRequest() {
 		TestAjaxHandler handler = new TestAjaxHandler(null, true);
 		assertTrue(handler.isAjaxRequest(request, response));
 	}
 
+	@Test
 	public void testIsNotAjaxRequest() {
 		TestAjaxHandler handler = new TestAjaxHandler(null, false);
 		assertFalse(handler.isAjaxRequest(request, response));
 	}
 
+	@Test
 	public void testIsAjaxRequestViaDelegate() {
 		TestAjaxHandler handler = new TestAjaxHandler(new TestAjaxHandler(null, true), false);
 		assertTrue(handler.isAjaxRequest(request, response));
 	}
 
+	@Test
 	public void testSendAjaxRedirect() throws Exception {
 		TestAjaxHandler handler = new TestAjaxHandler(null, true);
 		handler.sendAjaxRedirect("", request, response, false);
 		assertTrue(handler.wasAjaxRedirectInternalCalled);
 	}
 
+	@Test
 	public void testAjaxRedirectNotSent() throws Exception {
 		TestAjaxHandler handler = new TestAjaxHandler(null, false);
 		handler.sendAjaxRedirect("", request, response, false);
 		assertFalse(handler.wasAjaxRedirectInternalCalled());
 	}
 
+	@Test
 	public void testSendAjaxRedirectViaDelegate() throws Exception {
 		TestAjaxHandler handler = new TestAjaxHandler(new TestAjaxHandler(null, true), false);
 		handler.sendAjaxRedirect("", request, response, false);

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/DefaultFlowUrlHandlerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/DefaultFlowUrlHandlerTests.java
@@ -1,18 +1,20 @@
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.webflow.core.collection.CollectionUtils;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 
-public class DefaultFlowUrlHandlerTests extends TestCase {
+public class DefaultFlowUrlHandlerTests {
 	private DefaultFlowUrlHandler urlHandler = new DefaultFlowUrlHandler();
 
 	private MockHttpServletRequest request = new MockHttpServletRequest();
 
+	@Test
 	public void testGetFlowId() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -21,6 +23,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("foo", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowIdNoPathInfo() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app/foo.htm");
@@ -29,12 +32,14 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("app/foo", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowIdOnlyContextPath() {
 		request.setContextPath("/springtravel");
 		request.setRequestURI("/springtravel");
 		assertEquals("springtravel", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowExecutionKey() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -44,6 +49,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("12345", urlHandler.getFlowExecutionKey(request));
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrl() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -53,6 +59,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/bookHotel", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlNoPathInfo() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app/foo.htm");
@@ -61,6 +68,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/foo.htm", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlContextPathOnly() {
 		request.setContextPath("/springtravel");
 		request.setRequestURI("/springtravel");
@@ -68,6 +76,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlEmptyInput() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -77,6 +86,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/bookHotel", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithFlowInput() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -91,6 +101,7 @@ public class DefaultFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/bookHotel?foo=bar&bar=needs+encoding&baz=1&boop=", url);
 	}
 
+	@Test
 	public void testCreateFlowExecutionUrl() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/FilenameFlowUrlHandlerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/FilenameFlowUrlHandlerTests.java
@@ -15,15 +15,17 @@
  */
 package org.springframework.webflow.context.servlet;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-public class FilenameFlowUrlHandlerTests extends TestCase {
+public class FilenameFlowUrlHandlerTests {
 
 	private DefaultFlowUrlHandler urlHandler = new FilenameFlowUrlHandler();
 	private MockHttpServletRequest request = new MockHttpServletRequest();
 
+	@Test
 	public void testGetFlowId() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -32,6 +34,7 @@ public class FilenameFlowUrlHandlerTests extends TestCase {
 		assertEquals("foo", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowIdNoPathInfo() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app/foo.htm");
@@ -40,12 +43,14 @@ public class FilenameFlowUrlHandlerTests extends TestCase {
 		assertEquals("foo", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowIdOnlyContextPath() {
 		request.setContextPath("/springtravel");
 		request.setRequestURI("/springtravel");
 		assertEquals("", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithPathInfo() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -55,6 +60,7 @@ public class FilenameFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/bar", flowDefUrl);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithPathInfoNestedPath() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -64,6 +70,7 @@ public class FilenameFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/nestedPath/bar", flowDefUrl);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithPathInfoNestedPathAndFileExtension() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -73,6 +80,7 @@ public class FilenameFlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/nestedPath/bar.flow", flowDefUrl);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithServletPathAndFileExtension() {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/nestedPath/foo.flow");

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletContextMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletContextMapTests.java
@@ -15,11 +15,16 @@
  */
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockServletContext;
 
 /**
@@ -28,14 +33,14 @@ import org.springframework.mock.web.MockServletContext;
  * @author Ulrik Sandberg
  * @author Erwin Vervaet
  */
-public class HttpServletContextMapTests extends TestCase {
+public class HttpServletContextMapTests {
 
 	private HttpServletContextMap tested;
 
 	private MockServletContext context;
 
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		context = new MockServletContext();
 		// a fresh MockServletContext seems to already contain an element;
 		// that's confusing, so we remove it
@@ -44,39 +49,46 @@ public class HttpServletContextMapTests extends TestCase {
 		tested.put("SomeKey", "SomeValue");
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		context = null;
 		tested = null;
 	}
 
+	@Test
 	public void testIsEmpty() {
 		tested.remove("SomeKey");
 		assertEquals("size,", 0, tested.size());
 		assertEquals("isEmpty,", true, tested.isEmpty());
 	}
 
+	@Test
 	public void testSizeAddOne() {
 		assertEquals("size,", 1, tested.size());
 	}
 
+	@Test
 	public void testSizeAddTwo() {
 		tested.put("SomeOtherKey", "SomeOtherValue");
 		assertEquals("size,", 2, tested.size());
 	}
 
+	@Test
 	public void testContainsKey() {
 		assertEquals("containsKey,", true, tested.containsKey("SomeKey"));
 	}
 
+	@Test
 	public void testContainsValue() {
 		assertTrue(tested.containsValue("SomeValue"));
 	}
 
+	@Test
 	public void testGet() {
 		assertEquals("get,", "SomeValue", tested.get("SomeKey"));
 	}
 
+	@Test
 	public void testPut() {
 		Object old = tested.put("SomeKey", "SomeNewValue");
 
@@ -84,6 +96,7 @@ public class HttpServletContextMapTests extends TestCase {
 		assertEquals("new value,", "SomeNewValue", tested.get("SomeKey"));
 	}
 
+	@Test
 	public void testRemove() {
 		Object old = tested.remove("SomeKey");
 
@@ -91,6 +104,7 @@ public class HttpServletContextMapTests extends TestCase {
 		assertNull("should be gone", tested.get("SomeKey"));
 	}
 
+	@Test
 	public void testPutAll() {
 		Map<String, Object> otherMap = new HashMap<>();
 		otherMap.put("SomeOtherKey", "SomeOtherValue");
@@ -100,21 +114,25 @@ public class HttpServletContextMapTests extends TestCase {
 		assertEquals("SomeUpdatedValue", tested.get("SomeKey"));
 	}
 
+	@Test
 	public void testClear() {
 		tested.clear();
 		assertTrue(tested.isEmpty());
 	}
 
+	@Test
 	public void testKeySet() {
 		assertEquals(1, tested.keySet().size());
 		assertTrue(tested.keySet().contains("SomeKey"));
 	}
 
+	@Test
 	public void testValues() {
 		assertEquals(1, tested.values().size());
 		assertTrue(tested.values().contains("SomeValue"));
 	}
 
+	@Test
 	public void testEntrySet() {
 		assertEquals(1, tested.entrySet().size());
 		assertEquals("SomeKey", tested.entrySet().iterator().next().getKey());

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletRequestMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletRequestMapTests.java
@@ -15,10 +15,16 @@
  */
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Iterator;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
@@ -26,24 +32,25 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * 
  * @author Ulrik Sandberg
  */
-public class HttpServletRequestMapTests extends TestCase {
+public class HttpServletRequestMapTests {
 
 	private HttpServletRequestMap tested;
 
 	private MockHttpServletRequest request;
 
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		tested = new HttpServletRequestMap(request);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		request = null;
 		tested = null;
 	}
 
+	@Test
 	public void testGetAttribute() {
 		request.setAttribute("Some key", "Some value");
 		// perform test
@@ -51,12 +58,14 @@ public class HttpServletRequestMapTests extends TestCase {
 		assertEquals("Some value", result);
 	}
 
+	@Test
 	public void testSetAttribute() {
 		// perform test
 		tested.setAttribute("Some key", "Some value");
 		assertEquals("Some value", request.getAttribute("Some key"));
 	}
 
+	@Test
 	public void testRemoveAttribute() {
 		request.setAttribute("Some key", "Some value");
 		// perform test
@@ -64,6 +73,7 @@ public class HttpServletRequestMapTests extends TestCase {
 		assertNull(request.getAttribute("Some key"));
 	}
 
+	@Test
 	public void testGetAttributeNames() {
 		request.setAttribute("Some key", "Some value");
 		request.removeAttribute("javax.servlet.context.tempdir");

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletRequestParameterMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpServletRequestParameterMapTests.java
@@ -15,10 +15,16 @@
  */
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Iterator;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
@@ -26,24 +32,25 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * 
  * @author Ulrik Sandberg
  */
-public class HttpServletRequestParameterMapTests extends TestCase {
+public class HttpServletRequestParameterMapTests {
 
 	private HttpServletRequestParameterMap tested;
 
 	private MockHttpServletRequest request;
 
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		tested = new HttpServletRequestParameterMap(request);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		request = null;
 		tested = null;
 	}
 
+	@Test
 	public void testGetAttribute() {
 		request.setParameter("Some param", "Some value");
 		// perform test
@@ -51,6 +58,7 @@ public class HttpServletRequestParameterMapTests extends TestCase {
 		assertEquals("Some value", result);
 	}
 
+	@Test
 	public void testSetAttribute() {
 		// perform test
 		try {
@@ -61,6 +69,7 @@ public class HttpServletRequestParameterMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveAttribute() {
 		request.setParameter("Some param", "Some value");
 		// perform test
@@ -72,6 +81,7 @@ public class HttpServletRequestParameterMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetAttributeNames() {
 		request.setParameter("Some param", "Some value");
 		// perform test

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpSessionMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/HttpSessionMapTests.java
@@ -15,10 +15,18 @@
  */
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Iterator;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.util.WebUtils;
 
@@ -27,24 +35,25 @@ import org.springframework.web.util.WebUtils;
  * 
  * @author Ulrik Sandberg
  */
-public class HttpSessionMapTests extends TestCase {
+public class HttpSessionMapTests {
 
 	private HttpSessionMap tested;
 
 	private MockHttpServletRequest request;
 
-	protected void setUp() throws Exception {
-		super.setUp();
+	@Before
+	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		tested = new HttpSessionMap(request);
 	}
 
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		request = null;
 		tested = null;
 	}
 
+	@Test
 	public void testGetAttribute() {
 		request.getSession().setAttribute("Some key", "Some value");
 		// perform test
@@ -52,6 +61,7 @@ public class HttpSessionMapTests extends TestCase {
 		assertEquals("Some value", result);
 	}
 
+	@Test
 	public void testGetAttributeNullSession() {
 		request.setSession(null);
 		// perform test
@@ -59,12 +69,14 @@ public class HttpSessionMapTests extends TestCase {
 		assertNull("No value expected", result);
 	}
 
+	@Test
 	public void testSetAttribute() {
 		// perform test
 		tested.setAttribute("Some key", "Some value");
 		assertEquals("Some value", request.getSession().getAttribute("Some key"));
 	}
 
+	@Test
 	public void testRemoveAttribute() {
 		request.getSession().setAttribute("Some key", "Some value");
 		// perform test
@@ -72,6 +84,7 @@ public class HttpSessionMapTests extends TestCase {
 		assertNull(request.getSession().getAttribute("Some key"));
 	}
 
+	@Test
 	public void testRemoveAttributeNullSession() {
 		request.setSession(null);
 		// perform test
@@ -79,6 +92,7 @@ public class HttpSessionMapTests extends TestCase {
 		assertNull(request.getSession().getAttribute("Some key"));
 	}
 
+	@Test
 	public void testGetAttributeNames() {
 		request.getSession().setAttribute("Some key", "Some value");
 		// perform test
@@ -89,6 +103,7 @@ public class HttpSessionMapTests extends TestCase {
 		assertEquals("Some key", name);
 	}
 
+	@Test
 	public void testGetAttributeNamesNullSession() {
 		request.setSession(null);
 		// perform test
@@ -97,11 +112,13 @@ public class HttpSessionMapTests extends TestCase {
 		assertFalse("No elements expected", names.hasNext());
 	}
 
+	@Test
 	public void testGetSessionAsMutex() {
 		Object mutex = tested.getMutex();
 		assertSame(mutex, request.getSession());
 	}
 
+	@Test
 	public void testGetSessionMutex() {
 		Object object = new Object();
 		request.getSession().setAttribute(WebUtils.SESSION_MUTEX_ATTRIBUTE, object);

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/ServletExternalContextTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/ServletExternalContextTests.java
@@ -15,11 +15,17 @@
  */
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import java.io.Writer;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -28,7 +34,7 @@ import org.springframework.webflow.core.collection.LocalAttributeMap;
 /**
  * Unit tests for {@link ServletExternalContext}.
  */
-public class ServletExternalContextTests extends TestCase {
+public class ServletExternalContextTests {
 
 	private MockServletContext servletContext;
 
@@ -38,7 +44,8 @@ public class ServletExternalContextTests extends TestCase {
 
 	private ServletExternalContext context;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		servletContext = new MockServletContext();
 		servletContext.setAttribute("aFoo", "bar");
 		request = new MockHttpServletRequest();
@@ -48,52 +55,63 @@ public class ServletExternalContextTests extends TestCase {
 		context = new ServletExternalContext(servletContext, request, response);
 	}
 
+	@Test
 	public void testGetContextPath() {
 		request.setContextPath("/foo");
 		assertEquals("/foo", request.getContextPath());
 	}
 
+	@Test
 	public void testRequestParameters() {
 		assertTrue(context.getRequestParameterMap().isEmpty());
 	}
 
+	@Test
 	public void testGetAppAttribute() {
 		assertEquals("bar", context.getApplicationMap().get("aFoo"));
 	}
 
+	@Test
 	public void testGetSessionAttribute() {
 		assertEquals("bar", context.getSessionMap().get("sFoo"));
 	}
 
+	@Test
 	public void testGetRequestAttribute() {
 		assertEquals("bar", context.getRequestMap().get("rFoo"));
 	}
 
+	@Test
 	public void testGetNativeObjects() {
 		assertEquals(servletContext, context.getNativeContext());
 		assertEquals(request, context.getNativeRequest());
 		assertEquals(response, context.getNativeResponse());
 	}
 
+	@Test
 	public void testGetExecutionUrl() {
 		request.setRequestURI("/foo");
 		String url = context.getFlowExecutionUrl("foo", "e1s1");
 		assertEquals("/foo?execution=e1s1", url);
 	}
 
+	@Test
 	public void testNotAnAjaxRequest() {
 		assertFalse(context.isAjaxRequest());
 	}
 
+	@Test
 	public void testAjaxRequestAcceptHeader() {
 		context.setAjaxRequest(true);
 		assertTrue(context.isAjaxRequest());
 	}
 
+	@Test
 	public void testNotResponseCommitted() {
 		assertFalse(context.isResponseComplete());
 	}
 
+	@Test
 	public void testCommitExecutionRedirect() {
 		context.requestFlowExecutionRedirect();
 		assertTrue(context.getFlowExecutionRedirectRequested());
@@ -101,6 +119,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertTrue(context.isResponseCompleteFlowExecutionRedirect());
 	}
 
+	@Test
 	public void testCommitFlowRedirect() {
 		context.requestFlowDefinitionRedirect("foo", null);
 		assertTrue(context.getFlowDefinitionRedirectRequested());
@@ -110,6 +129,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertNotNull(context.getFlowRedirectFlowInput());
 	}
 
+	@Test
 	public void testCommitFlowRedirectWithInput() {
 		LocalAttributeMap<Object> input = new LocalAttributeMap<>();
 		context.requestFlowDefinitionRedirect("foo", input);
@@ -120,6 +140,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertEquals(input, context.getFlowRedirectFlowInput());
 	}
 
+	@Test
 	public void testCommitExternalRedirect() {
 		context.requestExternalRedirect("foo");
 		assertTrue(context.getExternalRedirectRequested());
@@ -129,6 +150,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertFalse(context.isResponseCompleteFlowExecutionRedirect());
 	}
 
+	@Test
 	public void testCommitExecutionRedirectPopup() {
 		context.requestFlowExecutionRedirect();
 		context.requestRedirectInPopup();
@@ -139,6 +161,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertTrue(context.isResponseCompleteFlowExecutionRedirect());
 	}
 
+	@Test
 	public void testCommitFlowRedirectPopup() {
 		context.requestFlowDefinitionRedirect("foo", null);
 		context.requestRedirectInPopup();
@@ -149,6 +172,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertFalse(context.isResponseAllowed());
 	}
 
+	@Test
 	public void testCommitExternalRedirectPopup() {
 		context.requestExternalRedirect("foo");
 		context.requestRedirectInPopup();
@@ -158,6 +182,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertFalse(context.isResponseAllowed());
 	}
 
+	@Test
 	public void testRecordResponseComplete() {
 		context.recordResponseComplete();
 		assertTrue(context.isResponseComplete());
@@ -165,6 +190,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertFalse(context.isResponseCompleteFlowExecutionRedirect());
 	}
 
+	@Test
 	public void testDoubleCommitResponse() {
 		context.recordResponseComplete();
 		try {
@@ -184,6 +210,7 @@ public class ServletExternalContextTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDoubleCommitResponseExecutionRedirectFirst() {
 		context.requestFlowExecutionRedirect();
 		try {
@@ -193,6 +220,7 @@ public class ServletExternalContextTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDoubleCommitResponseDefinitionRedirectFirst() {
 		context.requestFlowDefinitionRedirect("foo", null);
 		try {
@@ -202,6 +230,7 @@ public class ServletExternalContextTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDoubleCommitResponseExternalRedirectFirst() {
 		context.requestExternalRedirect("foo");
 		try {
@@ -211,6 +240,7 @@ public class ServletExternalContextTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRedirectInPopup() {
 		context.requestFlowExecutionRedirect();
 		assertTrue(context.isResponseComplete());
@@ -220,6 +250,7 @@ public class ServletExternalContextTests extends TestCase {
 		assertTrue(context.getRedirectInPopup());
 	}
 
+	@Test
 	public void testRedirectInPopupNoRedirectRequested() {
 		try {
 			context.requestRedirectInPopup();
@@ -229,12 +260,14 @@ public class ServletExternalContextTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetResponseWriter() throws IOException {
 		Writer writer = context.getResponseWriter();
 		writer.append('t');
 		assertEquals("t", response.getContentAsString());
 	}
 
+	@Test
 	public void testGetResponseWriterResponseComplete() throws IOException {
 		context.recordResponseComplete();
 		try {

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/WebFlow1FlowUrlHandlerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/servlet/WebFlow1FlowUrlHandlerTests.java
@@ -1,39 +1,45 @@
 package org.springframework.webflow.context.servlet;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.LinkedHashMap;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.webflow.core.collection.CollectionUtils;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 
-public class WebFlow1FlowUrlHandlerTests extends TestCase {
+public class WebFlow1FlowUrlHandlerTests {
 	private WebFlow1FlowUrlHandler urlHandler = new WebFlow1FlowUrlHandler();
 	private MockHttpServletRequest request = new MockHttpServletRequest();
 
+	@Test
 	public void testGetFlowId() {
 		request.addParameter("_flowId", "foo");
 		assertEquals("foo", urlHandler.getFlowId(request));
 	}
 
+	@Test
 	public void testGetFlowExecutionKey() {
 		request.addParameter("_flowExecutionKey", "12345");
 		assertEquals("12345", urlHandler.getFlowExecutionKey(request));
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrl() {
 		request.setRequestURI("/springtravel/app/flows");
 		String url = urlHandler.createFlowDefinitionUrl("bookHotel", null, request);
 		assertEquals("/springtravel/app/flows?_flowId=bookHotel", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlEmptyInput() {
 		request.setRequestURI("/springtravel/app/flows");
 		String url = urlHandler.createFlowDefinitionUrl("bookHotel", CollectionUtils.EMPTY_ATTRIBUTE_MAP, request);
 		assertEquals("/springtravel/app/flows?_flowId=bookHotel", url);
 	}
 
+	@Test
 	public void testCreateFlowDefinitionUrlWithFlowInput() {
 		request.setRequestURI("/springtravel/app/flows");
 		LocalAttributeMap<Object> input = new LocalAttributeMap<>(new LinkedHashMap<>());
@@ -45,6 +51,7 @@ public class WebFlow1FlowUrlHandlerTests extends TestCase {
 		assertEquals("/springtravel/app/flows?_flowId=bookHotel&foo=bar&bar=needs+encoding&baz=1&boop=", url);
 	}
 
+	@Test
 	public void testCreateFlowExecutionUrl() {
 		request.setRequestURI("/springtravel/app/flows");
 		String url = urlHandler.createFlowExecutionUrl("bookHotel", "12345", request);

--- a/spring-webflow/src/test/java/org/springframework/webflow/context/web/HttpSessionMapBindingListenerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/context/web/HttpSessionMapBindingListenerTests.java
@@ -15,11 +15,16 @@
  */
 package org.springframework.webflow.context.web;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.webflow.context.servlet.HttpSessionMap;
 import org.springframework.webflow.core.collection.AttributeMapBindingEvent;
@@ -30,18 +35,20 @@ import org.springframework.webflow.core.collection.AttributeMapBindingListener;
  * 
  * @author Erwin Vervaet
  */
-public class HttpSessionMapBindingListenerTests extends TestCase {
+public class HttpSessionMapBindingListenerTests {
 
 	private HttpServletRequest request;
 	private HttpSession session;
 	private TestAttributeMapBindingListener value;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		request = new MockHttpServletRequest();
 		session = request.getSession(true);
 		value = new TestAttributeMapBindingListener();
 	}
 
+	@Test
 	public void testValueBoundUnBound() {
 		value.valueBoundEvent = null;
 		value.valueUnboundEvent = null;

--- a/spring-webflow/src/test/java/org/springframework/webflow/conversation/impl/SessionBindingConversationManagerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/conversation/impl/SessionBindingConversationManagerTests.java
@@ -15,13 +15,20 @@
  */
 package org.springframework.webflow.conversation.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.context.ExternalContextHolder;
 import org.springframework.webflow.conversation.Conversation;
 import org.springframework.webflow.conversation.ConversationException;
@@ -33,18 +40,21 @@ import org.springframework.webflow.test.MockExternalContext;
 /**
  * Unit tests for {@link SessionBindingConversationManager}.
  */
-public class SessionBindingConversationManagerTests extends TestCase {
+public class SessionBindingConversationManagerTests {
 
 	private SessionBindingConversationManager conversationManager;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		conversationManager = new SessionBindingConversationManager();
 	}
 
-	protected void tearDown() throws Exception {
+	@After
+	public void tearDown() throws Exception {
 		ExternalContextHolder.setExternalContext(null);
 	}
 
+	@Test
 	public void testConversationLifeCycle() {
 		ExternalContextHolder.setExternalContext(new MockExternalContext());
 		Conversation conversation = conversationManager.beginConversation(new ConversationParameters("test", "test",
@@ -61,6 +71,7 @@ public class SessionBindingConversationManagerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNoPassivation() {
 		ExternalContextHolder.setExternalContext(new MockExternalContext());
 		Conversation conversation = conversationManager.beginConversation(new ConversationParameters("test", "test",
@@ -78,6 +89,7 @@ public class SessionBindingConversationManagerTests extends TestCase {
 		conversation2.unlock();
 	}
 
+	@Test
 	public void testPassivation() throws Exception {
 		MockExternalContext externalContext = new MockExternalContext();
 		ExternalContextHolder.setExternalContext(externalContext);
@@ -105,6 +117,7 @@ public class SessionBindingConversationManagerTests extends TestCase {
 		conversation.unlock();
 	}
 
+	@Test
 	public void testMaxConversations() {
 		conversationManager.setMaxConversations(2);
 		ExternalContextHolder.setExternalContext(new MockExternalContext());
@@ -129,6 +142,7 @@ public class SessionBindingConversationManagerTests extends TestCase {
 		assertNotNull(conversationManager.getConversation(conversation3.getId()));
 	}
 
+	@Test
 	public void testCustomSessionKey() {
 		conversationManager.setSessionKey("foo");
 		MockExternalContext context = new MockExternalContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/core/collection/CollectionUtilsTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/core/collection/CollectionUtilsTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.core.collection;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link CollectionUtils}.
  */
-public class CollectionUtilsTests extends TestCase {
+public class CollectionUtilsTests {
 
+	@Test
 	public void testSingleEntryMap() {
 		AttributeMap<Object> map1 = CollectionUtils.singleEntryMap("foo", "bar");
 		AttributeMap<Object> map2 = CollectionUtils.singleEntryMap("foo", "bar");

--- a/spring-webflow/src/test/java/org/springframework/webflow/core/collection/LocalAttributeMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/core/collection/LocalAttributeMapTests.java
@@ -15,20 +15,31 @@
  */
 package org.springframework.webflow.core.collection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.math.BigDecimal;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link LocalAttributeMap}.
  */
-public class LocalAttributeMapTests extends TestCase {
+public class LocalAttributeMapTests {
 
 	private LocalAttributeMap<Object> attributeMap = new LocalAttributeMap<>();
 
+	@Before
 	public void setUp() {
 		attributeMap.put("string", "A string");
 		attributeMap.put("integer", 12345);
@@ -42,21 +53,25 @@ public class LocalAttributeMapTests extends TestCase {
 		attributeMap.put("collection", new LinkedList<>());
 	}
 
+	@Test
 	public void testGet() {
 		TestBean bean = (TestBean) attributeMap.get("bean");
 		assertNotNull(bean);
 	}
 
+	@Test
 	public void testGetNull() {
 		TestBean bean = (TestBean) attributeMap.get("bogus");
 		assertNull(bean);
 	}
 
+	@Test
 	public void testGetRequiredType() {
 		TestBean bean = attributeMap.get("bean", TestBean.class);
 		assertNotNull(bean);
 	}
 
+	@Test
 	public void testGetWrongType() {
 		try {
 			attributeMap.get("bean", String.class);
@@ -66,6 +81,7 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetWithDefaultOption() {
 		TestBean d = new TestBean();
 		TestBean bean = (TestBean) attributeMap.get("bean", d);
@@ -73,17 +89,20 @@ public class LocalAttributeMapTests extends TestCase {
 		assertNotSame(bean, d);
 	}
 
+	@Test
 	public void testGetWithDefault() {
 		TestBean d = new TestBean();
 		TestBean bean = (TestBean) attributeMap.get("bogus", d);
 		assertSame(bean, d);
 	}
 
+	@Test
 	public void testGetRequired() {
 		TestBean bean = (TestBean) attributeMap.getRequired("bean");
 		assertNotNull(bean);
 	}
 
+	@Test
 	public void testGetRequiredNotPresent() {
 		try {
 			attributeMap.getRequired("bogus");
@@ -93,11 +112,13 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetRequiredOfType() {
 		TestBean bean = attributeMap.getRequired("bean", TestBean.class);
 		assertNotNull(bean);
 	}
 
+	@Test
 	public void testGetRequiredWrongType() {
 		try {
 			attributeMap.getRequired("bean", String.class);
@@ -107,11 +128,13 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetNumber() {
 		BigDecimal bd = attributeMap.getNumber("bigDecimal", BigDecimal.class);
 		assertEquals(new BigDecimal("12345.67"), bd);
 	}
 
+	@Test
 	public void testGetNumberWrongType() {
 		try {
 			attributeMap.getNumber("bigDecimal", Integer.class);
@@ -121,6 +144,7 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetNumberWithDefaultOption() {
 		BigDecimal d = new BigDecimal("1");
 		BigDecimal bd = attributeMap.getNumber("bigDecimal", BigDecimal.class, d);
@@ -128,6 +152,7 @@ public class LocalAttributeMapTests extends TestCase {
 		assertNotSame(d, bd);
 	}
 
+	@Test
 	public void testGetNumberWithDefault() {
 		BigDecimal d = new BigDecimal("1");
 		BigDecimal bd = attributeMap.getNumber("bogus", BigDecimal.class, d);
@@ -135,11 +160,13 @@ public class LocalAttributeMapTests extends TestCase {
 		assertSame(d, bd);
 	}
 
+	@Test
 	public void testGetNumberRequired() {
 		BigDecimal bd = attributeMap.getRequiredNumber("bigDecimal", BigDecimal.class);
 		assertEquals(new BigDecimal("12345.67"), bd);
 	}
 
+	@Test
 	public void testGetNumberRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredNumber("bogus", BigDecimal.class);
@@ -149,21 +176,25 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetInteger() {
 		Integer i = attributeMap.getInteger("integer");
 		assertEquals(new Integer(12345), i);
 	}
 
+	@Test
 	public void testGetIntegerNull() {
 		Integer i = attributeMap.getInteger("bogus");
 		assertNull(i);
 	}
 
+	@Test
 	public void testGetIntegerRequired() {
 		Integer i = attributeMap.getRequiredInteger("integer");
 		assertEquals(new Integer(12345), i);
 	}
 
+	@Test
 	public void testGetIntegerRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredInteger("bogus");
@@ -173,21 +204,25 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetLong() {
 		Long i = attributeMap.getLong("long");
 		assertEquals(new Long(12345), i);
 	}
 
+	@Test
 	public void testGetLongNull() {
 		Long i = attributeMap.getLong("bogus");
 		assertNull(i);
 	}
 
+	@Test
 	public void testGetLongRequired() {
 		Long i = attributeMap.getRequiredLong("long");
 		assertEquals(new Long(12345), i);
 	}
 
+	@Test
 	public void testGetLongRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredLong("bogus");
@@ -197,21 +232,25 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetString() {
 		String i = attributeMap.getString("string");
 		assertEquals("A string", i);
 	}
 
+	@Test
 	public void testGetStringNull() {
 		String i = attributeMap.getString("bogus");
 		assertNull(i);
 	}
 
+	@Test
 	public void testGetStringRequired() {
 		String i = attributeMap.getRequiredString("string");
 		assertEquals("A string", i);
 	}
 
+	@Test
 	public void testGetStringRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredString("bogus");
@@ -221,21 +260,25 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetBoolean() {
 		Boolean i = attributeMap.getBoolean("boolean");
 		assertEquals(Boolean.TRUE, i);
 	}
 
+	@Test
 	public void testGetBooleanNull() {
 		Boolean i = attributeMap.getBoolean("bogus");
 		assertNull(i);
 	}
 
+	@Test
 	public void testGetBooleanRequired() {
 		Boolean i = attributeMap.getRequiredBoolean("boolean");
 		assertEquals(Boolean.TRUE, i);
 	}
 
+	@Test
 	public void testGetBooleanRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredBoolean("bogus");
@@ -245,21 +288,25 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetArray() {
 		String[] i = attributeMap.getArray("stringArray", String[].class);
 		assertEquals(3, i.length);
 	}
 
+	@Test
 	public void testGetArrayNull() {
 		String[] i = attributeMap.getArray("A bogus array", String[].class);
 		assertNull(i);
 	}
 
+	@Test
 	public void testGetArrayRequired() {
 		String[] i = attributeMap.getRequiredArray("stringArray", String[].class);
 		assertEquals(3, i.length);
 	}
 
+	@Test
 	public void testGetArrayRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredArray("A bogus array", String[].class);
@@ -270,6 +317,7 @@ public class LocalAttributeMapTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testGetCollection() {
 		List<Object> i = attributeMap.getCollection("collection", List.class);
 		assertTrue(i instanceof LinkedList);
@@ -277,17 +325,20 @@ public class LocalAttributeMapTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testGetCollectionNull() {
 		List<Object> i = attributeMap.getCollection("bogus", List.class);
 		assertNull(i);
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testGetCollectionRequired() {
 		List<Object> i = attributeMap.getRequiredCollection("collection", List.class);
 		assertEquals(0, i.size());
 	}
 
+	@Test
 	public void testGetCollectionRequiredNotPresent() {
 		try {
 			attributeMap.getRequiredCollection("A bogus collection");
@@ -297,11 +348,13 @@ public class LocalAttributeMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetMap() {
 		Map<String, Object> map = attributeMap.asMap();
 		assertEquals(10, map.size());
 	}
 
+	@Test
 	public void testUnion() {
 		LocalAttributeMap<Object> one = new LocalAttributeMap<>();
 		one.put("foo", "bar");
@@ -318,6 +371,7 @@ public class LocalAttributeMapTests extends TestCase {
 		assertEquals("boo", three.get("bar"));
 	}
 
+	@Test
 	public void testEquality() {
 		LocalAttributeMap<String> map = new LocalAttributeMap<>();
 		map.put("foo", "bar");
@@ -328,6 +382,7 @@ public class LocalAttributeMapTests extends TestCase {
 		assertEquals(map, map2);
 	}
 
+	@Test
 	public void testExtract() {
 		assertEquals("A string", attributeMap.extract("string"));
 		assertFalse(attributeMap.contains("string"));

--- a/spring-webflow/src/test/java/org/springframework/webflow/core/collection/LocalParameterMapTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/core/collection/LocalParameterMapTests.java
@@ -15,21 +15,28 @@
  */
 package org.springframework.webflow.core.collection;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
  * Unit tests for {@link LocalParameterMap}.
  */
-public class LocalParameterMapTests extends TestCase {
+public class LocalParameterMapTests {
 
 	private LocalParameterMap parameterMap;
 
+	@Before
 	public void setUp() {
 		Map<String, Object> map = new HashMap<>();
 		map.put("string", "A string");
@@ -41,31 +48,37 @@ public class LocalParameterMapTests extends TestCase {
 		parameterMap = new LocalParameterMap(map);
 	}
 
+	@Test
 	public void testSize() {
 		assertTrue(!parameterMap.isEmpty());
 		assertEquals(6, parameterMap.size());
 	}
 
+	@Test
 	public void testGet() {
 		String value = parameterMap.get("string");
 		assertEquals("A string", value);
 	}
 
+	@Test
 	public void testGetNull() {
 		String value = parameterMap.get("bogus");
 		assertNull(value);
 	}
 
+	@Test
 	public void testGetRequired() {
 		String value = parameterMap.getRequired("string");
 		assertEquals("A string", value);
 	}
 
+	@Test
 	public void testGetRequiredWithConversion() {
 		Integer value = parameterMap.getRequired("integer", Integer.class);
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetRequiredNotPresent() {
 		try {
 			parameterMap.getRequired("bogus");
@@ -74,22 +87,26 @@ public class LocalParameterMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetWithDefaultOption() {
 		String value = parameterMap.get("string", "default");
 		assertEquals("A string", value);
 	}
 
+	@Test
 	public void testGetWithDefault() {
 		String value = parameterMap.get("bogus", "default");
 		assertEquals("default", value);
 	}
 
+	@Test
 	public void testGetWithDefaultAndConversion() {
 		Object value = parameterMap.get("bogus", Integer.class, 1);
 		assertEquals(1, value);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
 	public void testGetWithDefaultAndConversionNotAssignable() {
 		try {
 			parameterMap.get("bogus", (Class) Integer.class, "1");
@@ -99,21 +116,25 @@ public class LocalParameterMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetArray() {
 		String[] value = parameterMap.getArray("stringArray");
 		assertEquals(3, value.length);
 	}
 
+	@Test
 	public void testGetEmptyArray() {
 		String[] array = parameterMap.getArray("emptyArray");
 		assertEquals(0, array.length);
 	}
 
+	@Test
 	public void testGetArrayNull() {
 		String[] value = parameterMap.getArray("bogus");
 		assertNull(value);
 	}
 
+	@Test
 	public void testGetArrayRequired() {
 		String[] value = parameterMap.getRequiredArray("stringArray");
 		assertEquals(3, value.length);
@@ -126,6 +147,7 @@ public class LocalParameterMapTests extends TestCase {
 		assertEquals(new Integer(3), values[2]);
 	}
 
+	@Test
 	public void testGetRequiredArrayNotPresent() {
 		try {
 			parameterMap.getRequiredArray("bogus");
@@ -134,27 +156,32 @@ public class LocalParameterMapTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetSingleValueAsArray() {
 		String[] value = parameterMap.getArray("string");
 		assertEquals(1, value.length);
 		assertEquals("A string", value[0]);
 	}
 
+	@Test
 	public void testGetArrayAsSingleVaue() {
 		String value = parameterMap.get("stringArray");
 		assertEquals("1", value);
 	}
 
+	@Test
 	public void testGetEmptyArrayAsSingleVaue() {
 		String value = parameterMap.get("emptyArray");
 		assertEquals(null, value);
 	}
 
+	@Test
 	public void testGetConversion() {
 		Integer i = parameterMap.getInteger("integer");
 		assertEquals(new Integer(12345), i);
 	}
 
+	@Test
 	public void testGetArrayConversion() {
 		Integer[] i = parameterMap.getArray("stringArray", Integer.class);
 		assertEquals(i.length, 3);
@@ -170,81 +197,97 @@ public class LocalParameterMapTests extends TestCase {
 		assertEquals(new Integer(3), values[2]);
 	}
 
+	@Test
 	public void testGetNumber() {
 		Integer value = parameterMap.getNumber("integer", Integer.class);
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetRequiredNumber() {
 		Integer value = parameterMap.getRequiredNumber("integer", Integer.class);
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetNumberWithDefault() {
 		Integer value = parameterMap.getNumber("bogus", Integer.class, 12345);
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetInteger() {
 		Integer value = parameterMap.getInteger("integer");
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetRequiredInteger() {
 		Integer value = parameterMap.getRequiredInteger("integer");
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetIntegerWithDefault() {
 		Integer value = parameterMap.getInteger("bogus", 12345);
 		assertEquals(new Integer(12345), value);
 	}
 
+	@Test
 	public void testGetLong() {
 		Long value = parameterMap.getLong("integer");
 		assertEquals(new Long(12345), value);
 	}
 
+	@Test
 	public void testGetRequiredLong() {
 		Long value = parameterMap.getRequiredLong("integer");
 		assertEquals(new Long(12345), value);
 	}
 
+	@Test
 	public void testGetLongWithDefault() {
 		Long value = parameterMap.getLong("bogus", 12345L);
 		assertEquals(new Long(12345), value);
 	}
 
+	@Test
 	public void testGetBoolean() {
 		Boolean value = parameterMap.getBoolean("boolean");
 		assertEquals(Boolean.TRUE, value);
 	}
 
+	@Test
 	public void testGetRequiredBoolean() {
 		Boolean value = parameterMap.getRequiredBoolean("boolean");
 		assertEquals(Boolean.TRUE, value);
 	}
 
+	@Test
 	public void testGetBooleanWithDefault() {
 		Boolean value = parameterMap.getBoolean("bogus", true);
 		assertEquals(Boolean.TRUE, value);
 	}
 
+	@Test
 	public void testGetMultipart() {
 		MultipartFile file = parameterMap.getMultipartFile("multipartFile");
 		assertNotNull(file);
 	}
 
+	@Test
 	public void testGetRequiredMultipart() {
 		MultipartFile file = parameterMap.getRequiredMultipartFile("multipartFile");
 		assertNotNull(file);
 	}
 
+	@Test
 	public void testEquality() {
 		LocalParameterMap map1 = new LocalParameterMap(new HashMap<>(parameterMap.asMap()));
 		assertEquals(parameterMap, map1);
 	}
 
+	@Test
 	public void testAsAttributeMap() {
 		AttributeMap<Object> map = parameterMap.asAttributeMap();
 		assertEquals(map.asMap(), parameterMap.asMap());

--- a/spring-webflow/src/test/java/org/springframework/webflow/definition/registry/FlowDefinitionRegistryImplTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/definition/registry/FlowDefinitionRegistryImplTests.java
@@ -15,8 +15,14 @@
  */
 package org.springframework.webflow.definition.registry;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.definition.FlowDefinition;
@@ -25,7 +31,7 @@ import org.springframework.webflow.definition.StateDefinition;
 /**
  * Unit tests for {@link FlowDefinitionRegistryImpl}.
  */
-public class FlowDefinitionRegistryImplTests extends TestCase {
+public class FlowDefinitionRegistryImplTests {
 
 	private FlowDefinitionRegistryImpl registry = new FlowDefinitionRegistryImpl();
 
@@ -33,11 +39,13 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 
 	private BarFlow barFlow;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		fooFlow = new FooFlow();
 		barFlow = new BarFlow();
 	}
 
+	@Test
 	public void testNoSuchFlowDefinition() {
 		try {
 			registry.getFlowDefinition("bogus");
@@ -47,6 +55,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNullFlowDefinitionId() {
 		try {
 			registry.getFlowDefinition(null);
@@ -56,6 +65,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testBlankFlowDefinitionId() {
 		try {
 			registry.getFlowDefinition("");
@@ -65,12 +75,14 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterFlow() {
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(fooFlow));
 		assertTrue(registry.containsFlowDefinition("foo"));
 		assertEquals(fooFlow, registry.getFlowDefinition("foo"));
 	}
 
+	@Test
 	public void testGetFlowIds() {
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(fooFlow));
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(barFlow));
@@ -78,6 +90,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		assertEquals("foo", registry.getFlowDefinitionIds()[1]);
 	}
 
+	@Test
 	public void testRegisterFlowSameIds() {
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(fooFlow));
 		FooFlow newFlow = new FooFlow();
@@ -85,6 +98,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		assertSame(newFlow, registry.getFlowDefinition("foo"));
 	}
 
+	@Test
 	public void testRegisterMultipleFlows() {
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(fooFlow));
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(barFlow));
@@ -94,6 +108,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		assertEquals(barFlow, registry.getFlowDefinition("bar"));
 	}
 
+	@Test
 	public void testParentHierarchy() {
 		testRegisterMultipleFlows();
 		FlowDefinitionRegistryImpl child = new FlowDefinitionRegistryImpl();
@@ -106,6 +121,7 @@ public class FlowDefinitionRegistryImplTests extends TestCase {
 		assertEquals(barFlow, child.getFlowDefinition("bar"));
 	}
 
+	@Test
 	public void testDestroy() {
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(fooFlow));
 		registry.registerFlowDefinition(new StaticFlowDefinitionHolder(barFlow));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/ActionExecutorTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/ActionExecutorTests.java
@@ -15,8 +15,14 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.execution.ActionExecutionException;
 import org.springframework.webflow.execution.ActionExecutor;
 import org.springframework.webflow.execution.Event;
@@ -24,18 +30,20 @@ import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.TestAction;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ActionExecutorTests extends TestCase {
+public class ActionExecutorTests {
 
 	private MockRequestContext context;
 	private State state;
 	private Flow flow;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		flow = new Flow("myFlow");
 		state = new EndState(flow, "end");
 		context = new MockRequestContext(flow);
 	}
 
+	@Test
 	public void testExecuteAction() {
 		TestAction action = new TestAction();
 		Event result = ActionExecutor.execute(action, context);
@@ -43,6 +51,7 @@ public class ActionExecutorTests extends TestCase {
 		assertEquals("success", result.getId());
 	}
 
+	@Test
 	public void testExecuteActionInState() {
 		context.getMockFlowExecutionContext().getMockActiveSession().setState(state);
 		TestAction action = new TestAction();
@@ -51,6 +60,7 @@ public class ActionExecutorTests extends TestCase {
 		assertEquals("success", result.getId());
 	}
 
+	@Test
 	public void testExecuteActionWithException() {
 		TestAction action = new TestAction() {
 			protected Event doExecute(RequestContext context) throws Exception {
@@ -68,6 +78,7 @@ public class ActionExecutorTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testExecuteActionInStateWithException() {
 		context.getMockFlowExecutionContext().getMockActiveSession().setState(state);
 		TestAction action = new TestAction() {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/ActionStateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/ActionStateTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 import org.springframework.webflow.engine.support.MockTransitionCriteria;
 import org.springframework.webflow.execution.Action;
@@ -27,12 +30,13 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * Tests ActionState behavior
  * @author Keith Donald
  */
-public class ActionStateTests extends TestCase {
+public class ActionStateTests {
 
 	private Flow flow;
 	private ActionState state;
 	private MockRequestControlContext context;
 
+	@Before
 	public void setUp() {
 		flow = new Flow("myFlow");
 		state = new ActionState(flow, "actionState");
@@ -40,6 +44,7 @@ public class ActionStateTests extends TestCase {
 		context = new MockRequestControlContext(flow);
 	}
 
+	@Test
 	public void testExecuteSingleAction() {
 		state.getActionList().add(new TestAction());
 		state.getTransitionSet().add(new Transition(on("success"), to("finish")));
@@ -47,6 +52,7 @@ public class ActionStateTests extends TestCase {
 		assertEquals(1, ((TestAction) state.getActionList().get(0)).getExecutionCount());
 	}
 
+	@Test
 	public void testExecuteNothing() {
 		try {
 			state.enter(context);
@@ -56,6 +62,7 @@ public class ActionStateTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testExecuteActionCannotHandleResultEvent() {
 		state.getActionList().add(new TestAction());
 		try {
@@ -66,6 +73,7 @@ public class ActionStateTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testExecuteActionChain() {
 		state.getActionList().add(new TestAction("not mapped result"));
 		state.getActionList().add(new TestAction(null));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/AnnotatedObjectTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/AnnotatedObjectTests.java
@@ -15,24 +15,28 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.webflow.core.AnnotatedObject;
 
-public class AnnotatedObjectTests extends TestCase {
+public class AnnotatedObjectTests {
 
 	private AnnotatedObject object = new Flow("foo");
 
+	@Test
 	public void testSetCaption() {
 		object.setCaption("caption");
 		assertEquals("caption", object.getCaption());
 	}
 
+	@Test
 	public void testSetDescription() {
 		object.setDescription("description");
 		assertEquals("description", object.getDescription());
 	}
 
+	@Test
 	public void testPutCustomAttributes() {
 		object.getAttributes().put("foo", "bar");
 		assertEquals("bar", object.getAttributes().get("foo"));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/AnnotedActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/AnnotedActionTests.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.execution.AnnotatedAction;
 import org.springframework.webflow.execution.Event;
@@ -24,21 +26,24 @@ import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.execution.TestAction;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class AnnotedActionTests extends TestCase {
+public class AnnotedActionTests {
 
 	private AnnotatedAction action = new AnnotatedAction(new TestAction());
 
 	private MockRequestContext context;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		Flow flow = new Flow("myFlow");
 		context = new MockRequestContext(flow);
 	}
 
+	@Test
 	public void testBasicExecute() throws Exception {
 		assertEquals("success", action.execute(context).getId());
 	}
 
+	@Test
 	public void testExecuteWithCustomAttribute() throws Exception {
 		action.getAttributes().put("attr", "value");
 		action.setTargetAction(new AbstractAction() {
@@ -51,6 +56,7 @@ public class AnnotedActionTests extends TestCase {
 		assertEquals(0, context.getAttributes().size());
 	}
 
+	@Test
 	public void testExecuteWithChainOfCustomAttributes() throws Exception {
 		AnnotatedAction action2 = new AnnotatedAction(action);
 		action2.getAttributes().put("attr2", "value");
@@ -66,6 +72,7 @@ public class AnnotedActionTests extends TestCase {
 		assertEquals(0, context.getAttributes().size());
 	}
 
+	@Test
 	public void testExecuteWithName() throws Exception {
 		action.getAttributes().put("name", "foo");
 		action.setTargetAction(new AbstractAction() {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/DecisionStateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/DecisionStateTests.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 import org.springframework.webflow.engine.support.MockTransitionCriteria;
 import org.springframework.webflow.execution.Event;
@@ -27,8 +29,9 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * 
  * @author Keith Donald
  */
-public class DecisionStateTests extends TestCase {
+public class DecisionStateTests {
 
+	@Test
 	public void testIfDecision() {
 		Flow flow = new Flow("flow");
 		DecisionState state = new DecisionState(flow, "decisionState");
@@ -40,6 +43,7 @@ public class DecisionStateTests extends TestCase {
 		assertFalse(context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testElseDecision() {
 		Flow flow = new Flow("flow");
 		DecisionState state = new DecisionState(flow, "decisionState");
@@ -52,6 +56,7 @@ public class DecisionStateTests extends TestCase {
 		assertFalse(context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testCannotDecide() {
 		Flow flow = new Flow("flow");
 		DecisionState state = new DecisionState(flow, "decisionState");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/EndStateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/EndStateTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.binding.expression.EvaluationException;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionParser;
@@ -41,8 +44,9 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * Tests EndState behavior.
  * @author Keith Donald
  */
-public class EndStateTests extends TestCase {
+public class EndStateTests {
 
+	@Test
 	public void testEnterEndStateTerminateFlowExecution() {
 		Flow flow = new Flow("myFlow");
 		EndState state = new EndState(flow, "end");
@@ -51,6 +55,7 @@ public class EndStateTests extends TestCase {
 		assertFalse("Active", context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testEnterEndStateWithFinalResponseRenderer() {
 		Flow flow = new Flow("myFlow");
 		EndState state = new EndState(flow, "end");
@@ -61,6 +66,7 @@ public class EndStateTests extends TestCase {
 		assertTrue(action.executeCalled);
 	}
 
+	@Test
 	public void testEnterEndStateWithFinalResponseRendererResponseAlreadyComplete() {
 		Flow flow = new Flow("myFlow");
 		EndState state = new EndState(flow, "end");
@@ -72,6 +78,7 @@ public class EndStateTests extends TestCase {
 		assertFalse(action.executeCalled);
 	}
 
+	@Test
 	public void testEnterEndStateWithOutputMapper() {
 		Flow flow = new Flow("myFlow") {
 			@SuppressWarnings("unused")
@@ -92,6 +99,7 @@ public class EndStateTests extends TestCase {
 		state.enter(context);
 	}
 
+	@Test
 	public void testEnterEndStateTerminateFlowSession() {
 		final Flow subflow = new Flow("mySubflow");
 		EndState state = new EndState(subflow, "end");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/EventTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/EventTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.Event;
 
@@ -25,8 +28,9 @@ import org.springframework.webflow.execution.Event;
  * 
  * @author Keith Donald
  */
-public class EventTests extends TestCase {
+public class EventTests {
 
+	@Test
 	public void testNewEvent() {
 		Event event = new Event(this, "id");
 		assertEquals("id", event.getId());
@@ -34,6 +38,7 @@ public class EventTests extends TestCase {
 		assertTrue(event.getAttributes().isEmpty());
 	}
 
+	@Test
 	public void testEventNullSource() {
 		try {
 			new Event(null, "id");
@@ -43,6 +48,7 @@ public class EventTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testEventNullId() {
 		try {
 			new Event(this, null);
@@ -52,6 +58,7 @@ public class EventTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNewEventWithAttributes() {
 		LocalAttributeMap<Object> attrs = new LocalAttributeMap<>();
 		attrs.put("name", "value");
@@ -60,6 +67,7 @@ public class EventTests extends TestCase {
 		assertEquals(1, event.getAttributes().size());
 	}
 
+	@Test
 	public void testNewEventNullAttributes() {
 		Event event = new Event(this, "id", null);
 		assertTrue(event.getAttributes().isEmpty());

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowExecutionHandlerSetTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowExecutionHandlerSetTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.FlowExecutionException;
 import org.springframework.webflow.test.MockRequestControlContext;
 
@@ -25,12 +28,13 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * 
  * @author Erwin Vervaet
  */
-public class FlowExecutionHandlerSetTests extends TestCase {
+public class FlowExecutionHandlerSetTests {
 
 	Flow flow = new Flow("myFlow");
 	MockRequestControlContext context = new MockRequestControlContext(flow);
 	boolean handled;
 
+	@Test
 	public void testHandleException() {
 		FlowExecutionExceptionHandlerSet handlerSet = new FlowExecutionExceptionHandlerSet();
 		handlerSet.add(new TestStateExceptionHandler(NullPointerException.class, "null"));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowTests.java
@@ -15,10 +15,16 @@
  */
 package org.springframework.webflow.engine;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.support.FluentParserContext;
@@ -46,7 +52,7 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * 
  * @author Keith Donald
  */
-public class FlowTests extends TestCase {
+public class FlowTests {
 
 	private Flow flow = createSimpleFlow();
 
@@ -59,6 +65,7 @@ public class FlowTests extends TestCase {
 		return flow;
 	}
 
+	@Test
 	public void testAddStates() {
 		Flow flow = new Flow("myFlow");
 		new EndState(flow, "myState1");
@@ -73,6 +80,7 @@ public class FlowTests extends TestCase {
 		assertEquals("Wrong state:", "myState2", flow.getState("myState2").getId());
 	}
 
+	@Test
 	public void testAddDuplicateState() {
 		Flow flow = new Flow("myFlow");
 		new EndState(flow, "myState1");
@@ -84,6 +92,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testAddSameStateTwice() {
 		Flow flow = new Flow("myFlow");
 		EndState state = new EndState(flow, "myState1");
@@ -96,6 +105,7 @@ public class FlowTests extends TestCase {
 		assertEquals("State count wrong:", 1, flow.getStateCount());
 	}
 
+	@Test
 	public void testAddStateAlreadyInOtherFlow() {
 		Flow otherFlow = new Flow("myOtherFlow");
 		State state = new EndState(otherFlow, "myState1");
@@ -108,6 +118,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetStateNoStartState() {
 		Flow flow = new Flow("myFlow");
 		try {
@@ -118,6 +129,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetStateNoSuchState() {
 		try {
 			flow.getState("myState3");
@@ -127,11 +139,13 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetTransitionableState() {
 		assertEquals("Wrong state:", "myState1", flow.getTransitionableState("myState1").getId());
 		assertEquals("Wrong state:", "myState1", flow.getState("myState1").getId());
 	}
 
+	@Test
 	public void testGetStateNoSuchTransitionableState() {
 		try {
 			flow.getTransitionableState("myState2");
@@ -146,6 +160,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetPossibleOutcomes() {
 		Flow flow = new Flow("myFlow");
 		new EndState(flow, "myState1");
@@ -154,6 +169,7 @@ public class FlowTests extends TestCase {
 		assertEquals("myState2", flow.getPossibleOutcomes()[1]);
 	}
 
+	@Test
 	public void testAddActions() {
 		flow.getStartActionList().add(new TestMultiAction());
 		flow.getStartActionList().add(new TestMultiAction());
@@ -162,18 +178,21 @@ public class FlowTests extends TestCase {
 		assertEquals(1, flow.getEndActionList().size());
 	}
 
+	@Test
 	public void testAddGlobalTransition() {
 		Transition t = new Transition(to("myState2"));
 		flow.getGlobalTransitionSet().add(t);
 		assertSame(t, flow.getGlobalTransitionSet().toArray()[1]);
 	}
 
+	@Test
 	public void testStart() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		flow.start(context, new LocalAttributeMap<>());
 		assertEquals("Wrong start state", "myState1", context.getCurrentState().getId());
 	}
 
+	@Test
 	public void testStartWithoutStartState() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		try {
@@ -185,6 +204,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStartWithAction() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		TestAction action = new TestAction();
@@ -194,6 +214,7 @@ public class FlowTests extends TestCase {
 		assertEquals(1, action.getExecutionCount());
 	}
 
+	@Test
 	public void testStartWithVariables() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		flow.addVariable(new FlowVariable("var1", new VariableValueFactory() {
@@ -208,6 +229,7 @@ public class FlowTests extends TestCase {
 		context.getFlowScope().getRequired("var1", ArrayList.class);
 	}
 
+	@Test
 	public void testStartWithMapper() {
 		DefaultMapper attributeMapper = new DefaultMapper();
 		ExpressionParser parser = new WebFlowSpringELExpressionParser(new SpelExpressionParser());
@@ -223,6 +245,7 @@ public class FlowTests extends TestCase {
 		assertEquals("foo", context.getFlowScope().get("attr"));
 	}
 
+	@Test
 	public void testStartWithMapperButNoInput() {
 		DefaultMapper attributeMapper = new DefaultMapper();
 		ExpressionParser parser = new WebFlowSpringELExpressionParser(new SpelExpressionParser());
@@ -238,6 +261,7 @@ public class FlowTests extends TestCase {
 		assertNull(context.getFlowScope().get("attr"));
 	}
 
+	@Test
 	public void testOnEventNullCurrentState() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		Event event = new Event(this, "foo");
@@ -249,6 +273,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOnEventInvalidCurrentState() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		context.setCurrentState(flow.getStateInstance("myState2"));
@@ -262,6 +287,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testOnEvent() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		context.setCurrentState(flow.getStateInstance("myState1"));
@@ -273,6 +299,7 @@ public class FlowTests extends TestCase {
 		assertTrue(!context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testOnEventGlobalTransition() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		context.setCurrentState(flow.getStateInstance("myState1"));
@@ -284,6 +311,7 @@ public class FlowTests extends TestCase {
 		assertTrue(!context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testOnEventNoTransition() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		context.setCurrentState(flow.getStateInstance("myState1"));
@@ -297,6 +325,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testResume() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		context.setCurrentState(flow.getStateInstance("myState1"));
@@ -304,6 +333,7 @@ public class FlowTests extends TestCase {
 		assertTrue(context.getFlowScope().getBoolean("renderCalled"));
 	}
 
+	@Test
 	public void testEnd() {
 		TestAction action = new TestAction();
 		flow.getEndActionList().add(action);
@@ -313,6 +343,7 @@ public class FlowTests extends TestCase {
 		assertEquals(1, action.getExecutionCount());
 	}
 
+	@Test
 	public void testEndWithOutputMapper() {
 		DefaultMapper attributeMapper = new DefaultMapper();
 		ExpressionParser parser = new WebFlowSpringELExpressionParser(new SpelExpressionParser());
@@ -328,6 +359,7 @@ public class FlowTests extends TestCase {
 		assertEquals("foo", sessionOutput.get("attr"));
 	}
 
+	@Test
 	public void testHandleException() {
 		flow.getExceptionHandlerSet().add(
 				new TransitionExecutingFlowExecutionExceptionHandler().add(TestException.class, "myState2"));
@@ -339,6 +371,7 @@ public class FlowTests extends TestCase {
 		assertFalse(context.getFlowExecutionContext().isActive());
 	}
 
+	@Test
 	public void testHandleExceptionNoMatch() {
 		MockRequestControlContext context = new MockRequestControlContext(flow);
 		FlowExecutionException e = new FlowExecutionException(flow.getId(), flow.getStartState().getId(), "Oops!",
@@ -350,6 +383,7 @@ public class FlowTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDestroy() {
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.refresh();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowVariableTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/FlowVariableTests.java
@@ -1,14 +1,18 @@
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class FlowVariableTests extends TestCase {
+public class FlowVariableTests {
 
 	private boolean restoreCalled;
 
+	@Test
 	public void testCreateVariable() {
 		FlowVariable var = new FlowVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {
@@ -23,6 +27,7 @@ public class FlowVariableTests extends TestCase {
 		assertEquals("bar", context.getFlowScope().get("foo"));
 	}
 
+	@Test
 	public void testDestroyVariable() {
 		FlowVariable var = new FlowVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {
@@ -39,6 +44,7 @@ public class FlowVariableTests extends TestCase {
 		assertFalse(context.getFlowScope().contains("foo"));
 	}
 
+	@Test
 	public void testRestoreVariable() {
 		FlowVariable var = new FlowVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/StateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/StateTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.execution.FlowExecutionException;
 import org.springframework.webflow.execution.TestAction;
 import org.springframework.webflow.test.MockRequestControlContext;
@@ -26,7 +30,7 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * 
  * @author Keith Donald
  */
-public class StateTests extends TestCase {
+public class StateTests {
 
 	private Flow flow;
 
@@ -36,6 +40,7 @@ public class StateTests extends TestCase {
 
 	private boolean handled;
 
+	@Before
 	public void setUp() {
 		flow = new Flow("flow");
 		state = new State(flow, "myState") {
@@ -45,6 +50,7 @@ public class StateTests extends TestCase {
 		};
 	}
 
+	@Test
 	public void testStateEnter() {
 		assertEquals("myState", state.getId());
 		MockRequestControlContext context = new MockRequestControlContext(flow);
@@ -53,6 +59,7 @@ public class StateTests extends TestCase {
 		assertTrue(entered);
 	}
 
+	@Test
 	public void testStateEnterWithEntryAction() {
 		TestAction action = new TestAction();
 		state.getEntryActionList().add(action);
@@ -64,6 +71,7 @@ public class StateTests extends TestCase {
 		assertEquals(1, action.getExecutionCount());
 	}
 
+	@Test
 	public void testHandledException() {
 		state.getExceptionHandlerSet().add(new FlowExecutionExceptionHandler() {
 			public boolean canHandle(FlowExecutionException exception) {
@@ -81,6 +89,7 @@ public class StateTests extends TestCase {
 		assertTrue(handled);
 	}
 
+	@Test
 	public void testCouldNotHandleException() {
 		FlowExecutionException e = new FlowExecutionException(flow.getId(), state.getId(), "Whatev");
 		MockRequestControlContext context = new MockRequestControlContext(flow);

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/SubflowStateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/SubflowStateTests.java
@@ -15,15 +15,14 @@
  */
 package org.springframework.webflow.engine;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collections;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.EvaluationException;
 import org.springframework.binding.expression.support.AbstractGetValueExpression;
-import org.springframework.binding.mapping.Mapper;
-import org.springframework.binding.mapping.MappingResult;
-import org.springframework.binding.mapping.MappingResults;
 import org.springframework.binding.mapping.impl.DefaultMappingResults;
 import org.springframework.webflow.core.collection.AttributeMap;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
@@ -39,13 +38,14 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * 
  * @author Keith Donald
  */
-public class SubflowStateTests extends TestCase {
+public class SubflowStateTests {
 
 	private Flow parentFlow;
 	private SubflowState subflowState;
 	private Flow subflow;
 	private MockRequestControlContext context;
 
+	@Before
 	public void setUp() {
 		parentFlow = new Flow("parent");
 		subflow = new Flow("child");
@@ -58,6 +58,7 @@ public class SubflowStateTests extends TestCase {
 		context.setCurrentState(subflowState);
 	}
 
+	@Test
 	public void testEnter() {
 		new State(subflow, "whatev") {
 			protected void doEnter(RequestControlContext context) throws FlowExecutionException {
@@ -68,6 +69,7 @@ public class SubflowStateTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testEnterWithInput() {
 		subflowState.setAttributeMapper(new SubflowAttributeMapper() {
 			public MutableAttributeMap<Object> createSubflowInput(RequestContext context) {
@@ -91,6 +93,7 @@ public class SubflowStateTests extends TestCase {
 	}
 
 	@SuppressWarnings("unchecked")
+	@Test
 	public void testReturnWithOutput() {
 		subflowState.setAttributeMapper(new SubflowAttributeMapper() {
 			public MutableAttributeMap<Object> createSubflowInput(RequestContext context) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/TransitionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/TransitionTests.java
@@ -15,17 +15,21 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 import org.springframework.webflow.execution.FlowExecutionException;
-import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.test.MockRequestControlContext;
 
-public class TransitionTests extends TestCase {
+public class TransitionTests {
 
 	private boolean exitCalled;
 
+	@Test
 	public void testExecuteTransitionFromState() {
 		Flow flow = new Flow("flow");
 		final TransitionableState source = new TransitionableState(flow, "state 1") {
@@ -53,6 +57,7 @@ public class TransitionTests extends TestCase {
 		assertSame(target, context.getCurrentState());
 	}
 
+	@Test
 	public void testExecuteTransitionWithNullSourceState() {
 		Flow flow = new Flow("flow");
 		final TransitionableState target = new TransitionableState(flow, "state 2") {
@@ -70,6 +75,7 @@ public class TransitionTests extends TestCase {
 		assertSame(target, context.getCurrentState());
 	}
 
+	@Test
 	public void testExecuteTransitionNullTargetState() {
 		Flow flow = new Flow("flow");
 		final TransitionableState source = new TransitionableState(flow, "state 1") {
@@ -90,6 +96,7 @@ public class TransitionTests extends TestCase {
 		assertSame(source, context.getCurrentState());
 	}
 
+	@Test
 	public void testExecuteTransitionNullTargetStateResolver() {
 		Flow flow = new Flow("flow");
 		final TransitionableState source = new TransitionableState(flow, "state 1") {
@@ -109,6 +116,7 @@ public class TransitionTests extends TestCase {
 		assertSame(source, context.getCurrentState());
 	}
 
+	@Test
 	public void testTransitionExecutionRefused() {
 		Flow flow = new Flow("flow");
 		final TransitionableState source = new TransitionableState(flow, "state 1") {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/ViewStateTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/ViewStateTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.TestBean;
 import org.springframework.webflow.engine.support.ActionTransitionCriteria;
 import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
@@ -31,8 +35,9 @@ import org.springframework.webflow.test.MockRequestControlContext;
  * Tests that ViewState logic is correct.
  * @author Keith Donald
  */
-public class ViewStateTests extends TestCase {
+public class ViewStateTests {
 
+	@Test
 	public void testEnterViewStateRenderResponse() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -46,6 +51,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateRenderNotAllowed() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -60,6 +66,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateResponseAlreadyComplete() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -73,6 +80,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateRedirectResponseAlreadyComplete() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -86,6 +94,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateWithVariables() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -106,6 +115,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getMockExternalContext().getFlowExecutionRedirectRequested());
 	}
 
+	@Test
 	public void testEnterViewStateWithLocalRedirect() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -119,6 +129,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateWithNoLocalRedirect() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -132,6 +143,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateRedirectInPopup() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -147,6 +159,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testEnterViewStateWithAlwaysRedirectOnPause() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -160,6 +173,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testResumeViewStateForRefresh() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -175,6 +189,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testResumeViewStateForRefreshResponseCompleteRecorded() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -193,6 +208,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testResumeViewStateRestoreVariables() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -215,6 +231,7 @@ public class ViewStateTests extends TestCase {
 		assertEquals("Restored", ((TestBean) context.getViewScope().get("foo")).datum1);
 	}
 
+	@Test
 	public void testResumeViewStateForEventWithTransitionFlowEnded() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -233,6 +250,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(testAction.isExecuted());
 	}
 
+	@Test
 	public void testResumeViewStateForEventWithTransitionStateExited() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -251,6 +269,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlowScope().contains("saveStateCalled"));
 	}
 
+	@Test
 	public void testResumeViewStateForEventWithTransitionStateExitedNoRedirect() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -269,6 +288,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlowScope().contains("saveStateCalled"));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNotExitedNonAjax() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -293,6 +313,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains(View.USER_EVENT_STATE_ATTRIBUTE));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNotExitedNonAjaxResponseNotAllowed() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -315,6 +336,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNotExitedNonAjaxRedirectEnabled() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -339,6 +361,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getFlashScope().contains("foo"));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNotExitedAjax() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -364,6 +387,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains(View.USER_EVENT_STATE_ATTRIBUTE));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNoExitActionRecordedResponseComplete() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -395,6 +419,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getFlashScope().contains(View.USER_EVENT_STATE_ATTRIBUTE));
 	}
 
+	@Test
 	public void testResumeViewStateForEventStateNoExitActionRecordedExecutionRedirect() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -426,6 +451,7 @@ public class ViewStateTests extends TestCase {
 		assertEquals(StubViewFactory.USER_EVENT_STATE, context.getFlashScope().get(View.USER_EVENT_STATE_ATTRIBUTE));
 	}
 
+	@Test
 	public void testRedirectInSameStateOverridesAlwaysRedirectOnPause() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -443,6 +469,7 @@ public class ViewStateTests extends TestCase {
 		assertTrue(context.getMockExternalContext().getFlowExecutionRedirectRequested());
 	}
 
+	@Test
 	public void testEmbeddedModeOverridesRedirectInSameState() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -458,6 +485,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getMockExternalContext().getFlowExecutionRedirectRequested());
 	}
 
+	@Test
 	public void testViewStateRedirectOverridesEmbeddedMode() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();
@@ -474,6 +502,7 @@ public class ViewStateTests extends TestCase {
 		assertFalse(context.getMockExternalContext().getFlowExecutionRedirectRequested());
 	}
 
+	@Test
 	public void testResumeViewStateForEventDestroyVariables() {
 		Flow flow = new Flow("myFlow");
 		StubViewFactory viewFactory = new StubViewFactory();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/ViewVariableTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/ViewVariableTests.java
@@ -1,14 +1,18 @@
 package org.springframework.webflow.engine;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.test.MockRequestControlContext;
 
-public class ViewVariableTests extends TestCase {
+public class ViewVariableTests {
 
 	private boolean restoreCalled;
 
+	@Test
 	public void testCreateVariable() {
 		ViewVariable var = new ViewVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {
@@ -26,6 +30,7 @@ public class ViewVariableTests extends TestCase {
 		assertEquals("bar", context.getViewScope().get("foo"));
 	}
 
+	@Test
 	public void testDestroyVariable() {
 		ViewVariable var = new ViewVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {
@@ -45,6 +50,7 @@ public class ViewVariableTests extends TestCase {
 		assertFalse(context.getViewScope().contains("foo"));
 	}
 
+	@Test
 	public void testRestoreVariable() {
 		ViewVariable var = new ViewVariable("foo", new VariableValueFactory() {
 			public Object createInitialValue(RequestContext context) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/DefaultFlowHolderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/DefaultFlowHolderTests.java
@@ -1,7 +1,9 @@
 package org.springframework.webflow.engine.builder;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -11,23 +13,26 @@ import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.builder.support.AbstractFlowBuilder;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 
-public class DefaultFlowHolderTests extends TestCase {
+public class DefaultFlowHolderTests {
 	private DefaultFlowHolder holder;
 	private FlowAssembler assembler;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		MockFlowBuilderContext context = new MockFlowBuilderContext("flowId");
 		context.getFlowBuilderServices().setApplicationContext(new StaticApplicationContext());
 		FlowAssembler assembler = new FlowAssembler(new SimpleFlowBuilder(), context);
 		holder = new DefaultFlowHolder(assembler);
 	}
 
+	@Test
 	public void testGetFlowDefinition() {
 		FlowDefinition flow = holder.getFlowDefinition();
 		assertEquals("flowId", flow.getId());
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testGetFlowDefinitionWithChangesRefreshed() {
 		assembler = new FlowAssembler(new ChangeDetectableFlowBuilder(), new MockFlowBuilderContext("flowId"));
 		holder = new DefaultFlowHolder(assembler);
@@ -36,10 +41,12 @@ public class DefaultFlowHolderTests extends TestCase {
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testDestroyNotInitialized() {
 		holder.destroy();
 	}
 
+	@Test
 	public void testDestroy() {
 		holder.getFlowDefinition();
 		holder.destroy();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/FlowAssemblerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/FlowAssemblerTests.java
@@ -1,22 +1,27 @@
 package org.springframework.webflow.engine.builder;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 
-public class FlowAssemblerTests extends TestCase {
+public class FlowAssemblerTests {
 	private FlowBuilder builder;
 	private FlowAssembler assembler;
 	private FlowBuilderContext builderContext;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		builder = EasyMock.createMock(FlowBuilder.class);
 		builderContext = new MockFlowBuilderContext("search");
 		assembler = new FlowAssembler(builder, builderContext);
 	}
 
+	@Test
 	public void testAssembleFlow() {
 		builder.init(builderContext);
 		builder.dispose();
@@ -35,6 +40,7 @@ public class FlowAssemblerTests extends TestCase {
 		EasyMock.verify(builder);
 	}
 
+	@Test
 	public void testDisposeCalledOnException() {
 		builder.init(builderContext);
 		EasyMock.expectLastCall().andThrow(new IllegalArgumentException());

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilderTests.java
@@ -1,10 +1,16 @@
 package org.springframework.webflow.engine.builder.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -48,15 +54,17 @@ import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class FlowModelFlowBuilderTests extends TestCase {
+public class FlowModelFlowBuilderTests {
 	private FlowModel model;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
 		beanFactory.addBean("bean", new Object());
 		model = new FlowModel();
 	}
 
+	@Test
 	public void testBuildIncompleteFlow() {
 		try {
 			getFlow(model);
@@ -70,6 +78,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		return new LinkedList<>(Arrays.asList(a));
 	}
 
+	@Test
 	public void testBuildFlowWithEndState() {
 		model.setStates(asList(new EndStateModel("end")));
 		Flow flow = getFlow(model);
@@ -77,6 +86,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testBuildFlowWithDefaultStartState() {
 		model.setStates(asList(new EndStateModel("end")));
 		Flow flow = getFlow(model);
@@ -84,6 +94,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testBuildFlowWithStartStateAttribute() {
 		model.setStartStateId("end");
 		model.setStates(asList(new EndStateModel("foo"), new EndStateModel("end")));
@@ -92,6 +103,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testCustomFlowAttribute() {
 		AttributeModel attribute1 = new AttributeModel("foo", "bar");
 		AttributeModel attribute2 = new AttributeModel("number", "1");
@@ -104,6 +116,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals(1, flow.getAttributes().get("number"));
 	}
 
+	@Test
 	public void testPersistenceContextFlow() {
 		model.setPersistenceContext(new PersistenceContextModel());
 		model.setStates(asList(new EndStateModel("end")));
@@ -112,6 +125,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue((Boolean) flow.getAttributes().get("persistenceContext"));
 	}
 
+	@Test
 	public void testFlowInputOutputMapping() {
 		InputModel input1 = new InputModel("foo", "flowScope.foo");
 		InputModel input2 = new InputModel("foo", "flowScope.bar");
@@ -157,6 +171,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertNull(outcome.getOutput().get("notReached"));
 	}
 
+	@Test
 	public void testFlowSecured() {
 		model.setSecured(new SecuredModel("ROLE_USER"));
 		model.setStates(asList(new EndStateModel("end")));
@@ -168,6 +183,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(rule.getAttributes().contains("ROLE_USER"));
 	}
 
+	@Test
 	public void testFlowSecuredState() {
 		EndStateModel end = new EndStateModel("end");
 		end.setSecured(new SecuredModel("ROLE_USER"));
@@ -181,6 +197,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(rule.getAttributes().contains("ROLE_USER"));
 	}
 
+	@Test
 	public void testFlowSecuredTransition() {
 		model.setStates(asList(new EndStateModel("end")));
 		TransitionModel transition = new TransitionModel();
@@ -196,6 +213,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(rule.getAttributes().contains("ROLE_USER"));
 	}
 
+	@Test
 	public void testFlowVariable() {
 		model.setVars(asList(new VarModel("flow-foo", "org.springframework.webflow.TestBean")));
 		model.setStates(asList(new EndStateModel("end")));
@@ -203,6 +221,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("flow-foo", flow.getVariable("flow-foo").getName());
 	}
 
+	@Test
 	public void testViewStateVariable() {
 		ViewStateModel view = new ViewStateModel("view");
 		view.setVars(asList(new VarModel("foo", "org.springframework.webflow.TestBean")));
@@ -211,6 +230,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertNotNull(((ViewState) flow.getStateInstance("view")).getVariable("foo"));
 	}
 
+	@Test
 	public void testViewStateRedirect() {
 		ViewStateModel view = new ViewStateModel("view");
 		view.setRedirect("true");
@@ -219,6 +239,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(((ViewState) flow.getStateInstance("view")).getRedirect());
 	}
 
+	@Test
 	public void testViewStatePopup() {
 		ViewStateModel view = new ViewStateModel("view");
 		view.setPopup("true");
@@ -227,6 +248,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(((ViewState) flow.getStateInstance("view")).getPopup());
 	}
 
+	@Test
 	public void testViewStateFlowRedirect() {
 		ViewStateModel state = new ViewStateModel("view");
 		state.setView("flowRedirect:myFlow?input=#{flowScope.foo}");
@@ -238,6 +260,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(avf.getAction() instanceof FlowDefinitionRedirectAction);
 	}
 
+	@Test
 	public void testViewStateExternalRedirect() {
 		ViewStateModel state = new ViewStateModel("view");
 		state.setView("externalRedirect:https://www.paypal.com?_callbackUrl=#{flowExecutionUri}");
@@ -249,6 +272,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertTrue(avf.getAction() instanceof ExternalRedirectAction);
 	}
 
+	@Test
 	public void testResourceBackedFlowBuilder() {
 		ClassPathResource resource = new ClassPathResource("flow-endstate.xml", XmlFlowModelBuilderTests.class);
 		Flow flow = getFlow(resource);
@@ -256,6 +280,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("end", flow.getStartState().getId());
 	}
 
+	@Test
 	public void testResourceBackedFlowBuilderWithMessages() {
 		ClassPathResource resource = new ClassPathResource("resources/flow.xml", FlowModelFlowBuilderTests.class);
 		Flow flow = getFlow(resource);
@@ -263,6 +288,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("bar", flow.getApplicationContext().getMessage("foo", null, null));
 	}
 
+	@Test
 	public void testAbstractFlow() {
 		model.setAbstract("true");
 		try {
@@ -273,6 +299,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testExceptionHandlers() {
 		FlowModel model = new FlowModel();
 		model.setStates(asList(new EndStateModel("state")));
@@ -293,6 +320,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals(1, flow.getExceptionHandlerSet().size());
 	}
 
+	@Test
 	public void testSetActionWithResultType() throws Exception {
 		SetModel setModel = new SetModel("flowScope.stringArray", "intArray");
 		setModel.setType("java.lang.String[]");
@@ -308,6 +336,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("2", expected[1]);
 	}
 
+	@Test
 	public void testSetActionWithImplicitTypeConversion() throws Exception {
 		SetModel setModel = new SetModel("testBean.stringArray", "intArray");
 		model.setOnStartActions(asList(setModel));
@@ -324,6 +353,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("2", expected.stringArray[1]);
 	}
 
+	@Test
 	public void testEvaluateActionWithResultType() throws Exception {
 		EvaluateModel evaluateModel = new EvaluateModel("testBean.getIntegers()");
 		evaluateModel.setResult("flowScope.stringArray");
@@ -340,6 +370,7 @@ public class FlowModelFlowBuilderTests extends TestCase {
 		assertEquals("2", expected[1]);
 	}
 
+	@Test
 	public void testEvaluateActionWithELExpression() throws Exception {
 		EvaluateModel evaluateModel = new EvaluateModel("testBean.getIntegers()");
 		evaluateModel.setResult("flowScope.stringArray");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/support/TextToTargetStateResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/support/TextToTargetStateResolverTests.java
@@ -15,21 +15,21 @@
  */
 package org.springframework.webflow.engine.builder.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.TargetStateResolver;
 import org.springframework.webflow.engine.Transition;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class TextToTargetStateResolverTests extends TestCase {
+public class TextToTargetStateResolverTests {
 
 	private MockFlowBuilderContext serviceLocator = new MockFlowBuilderContext("flowId");
 	private TextToTargetStateResolver converter = new TextToTargetStateResolver(serviceLocator);
 
-	public void setUp() {
-	}
-
+	@Test
 	public void testStatic() throws Exception {
 		String expression = "mockState";
 		TargetStateResolver resolver = (TargetStateResolver) converter.convertSourceToTargetClass(expression,
@@ -39,6 +39,7 @@ public class TextToTargetStateResolverTests extends TestCase {
 		assertEquals("mockState", resolver.resolveTargetState(transition, null, context).getId());
 	}
 
+	@Test
 	public void testDynamic() throws Exception {
 		String expression = "#{flowScope.lastState}";
 		TargetStateResolver resolver = (TargetStateResolver) converter.convertSourceToTargetClass(expression,
@@ -49,6 +50,7 @@ public class TextToTargetStateResolverTests extends TestCase {
 		assertEquals("mockState", resolver.resolveTargetState(transition, null, context).getId());
 	}
 
+	@Test
 	public void testNull() throws Exception {
 		String expression = null;
 		TargetStateResolver resolver = (TargetStateResolver) converter.convertSourceToTargetClass(expression,
@@ -56,6 +58,7 @@ public class TextToTargetStateResolverTests extends TestCase {
 		assertNull(resolver);
 	}
 
+	@Test
 	public void testEmpty() throws Exception {
 		String expression = "";
 		TargetStateResolver resolver = (TargetStateResolver) converter.convertSourceToTargetClass(expression,

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/support/TextToTransitionCriteriaTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/builder/support/TextToTransitionCriteriaTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.webflow.engine.builder.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
-import org.springframework.binding.expression.Expression;
-import org.springframework.binding.expression.ExpressionParser;
-import org.springframework.binding.expression.ParserContext;
-import org.springframework.binding.expression.ParserException;
+import org.junit.After;
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.TransitionCriteria;
@@ -31,16 +31,17 @@ import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class TextToTransitionCriteriaTests extends TestCase {
+public class TextToTransitionCriteriaTests {
 
 	private MockFlowBuilderContext serviceLocator = new MockFlowBuilderContext("flowId");
 	private TextToTransitionCriteria converter = new TextToTransitionCriteria(serviceLocator);
 
-	@Override
-	protected void tearDown() {
+	@After
+	public void tearDown() {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testAny() throws Exception {
 		String expression = "*";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -55,6 +56,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 				converter.convertSourceToTargetClass(null, TransitionCriteria.class));
 	}
 
+	@Test
 	public void testStaticEventId() throws Exception {
 		String expression = "sample";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -63,6 +65,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 		assertTrue("Criterion should evaluate to true", criterion.test(ctx));
 	}
 
+	@Test
 	public void testTrueEvaluation() throws Exception {
 		String expression = "#{flowScope.foo == 'bar'}";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -71,6 +74,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 		assertTrue("Criterion should evaluate to true", criterion.test(ctx));
 	}
 
+	@Test
 	public void testFalseEvaluation() throws Exception {
 		String expression = "#{flowScope.foo != 'bar'}";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -79,6 +83,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 		assertFalse("Criterion should evaluate to false", criterion.test(ctx));
 	}
 
+	@Test
 	public void testNonStringEvaluation() throws Exception {
 		String expression = "#{3 + 4}";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -88,6 +93,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 		assertTrue("Criterion should evaluate to true", criterion.test(ctx));
 	}
 
+	@Test
 	public void testCurrenEventEval() throws Exception {
 		String expression = "#{currentEvent.id == 'submit'}";
 		TransitionCriteria criterion = (TransitionCriteria) converter.convertSourceToTargetClass(expression,
@@ -97,6 +103,7 @@ public class TextToTransitionCriteriaTests extends TestCase {
 		assertTrue("Criterion should evaluate to true", criterion.test(ctx));
 	}
 
+	@Test
 	public void testNullExpressionEvaluation() throws Exception {
 		serviceLocator.getFlowBuilderServices()
 				.setExpressionParser((expressionString, context) -> new StaticExpression(null));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/impl/FlowExecutionImplFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/impl/FlowExecutionImplFactoryTests.java
@@ -15,8 +15,15 @@
  */
 package org.springframework.webflow.engine.impl;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.definition.FlowDefinition;
@@ -41,7 +48,7 @@ import org.springframework.webflow.test.MockFlowExecutionKey;
 /**
  * Test case for {@link FlowExecutionImplFactory}.
  */
-public class FlowExecutionImplFactoryTests extends TestCase {
+public class FlowExecutionImplFactoryTests {
 
 	private FlowExecutionImplFactory factory = new FlowExecutionImplFactory();
 
@@ -57,11 +64,13 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 
 	private boolean removeAllSnapshotsCalled;
 
+	@Before
 	public void setUp() {
 		flowDefinition = new Flow("flow");
 		new EndState(flowDefinition, "end");
 	}
 
+	@Test
 	public void testCreate() {
 		FlowExecution execution = factory.createFlowExecution(flowDefinition);
 		assertSame(flowDefinition, execution.getDefinition());
@@ -69,6 +78,7 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 		assertFalse(execution.isActive());
 	}
 
+	@Test
 	public void testCreateNullArgument() {
 		try {
 			factory.createFlowExecution(null);
@@ -78,6 +88,7 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCreateWithExecutionAttributes() {
 		MutableAttributeMap<Object> attributes = new LocalAttributeMap<>();
 		attributes.put("foo", "bar");
@@ -87,6 +98,7 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 		assertSame("Flow execution attributes are global", attributes.asMap(), execution.getAttributes().asMap());
 	}
 
+	@Test
 	public void testCreateWithExecutionListener() {
 		FlowExecutionListener listener1 = new FlowExecutionListener() {
 			public void sessionStarting(RequestContext context, FlowSession session, MutableAttributeMap<?> input) {
@@ -100,6 +112,7 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 		assertTrue(starting);
 	}
 
+	@Test
 	public void testCreateWithExecutionKeyFactory() {
 		State state = new State(flowDefinition, "state") {
 			protected void doEnter(RequestControlContext context) throws FlowExecutionException {
@@ -120,6 +133,7 @@ public class FlowExecutionImplFactoryTests extends TestCase {
 		assertNull(execution.getKey());
 	}
 
+	@Test
 	public void testRestoreExecutionState() {
 		FlowExecutionImpl flowExecution = (FlowExecutionImpl) factory.createFlowExecution(flowDefinition);
 		LocalAttributeMap<Object> executionAttributes = new LocalAttributeMap<>();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/impl/FlowExecutionImplTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/impl/FlowExecutionImplTests.java
@@ -15,8 +15,15 @@
  */
 package org.springframework.webflow.engine.impl;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.binding.message.MessageBuilder;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
 import org.springframework.webflow.definition.FlowDefinition;
@@ -46,9 +53,10 @@ import org.springframework.webflow.test.MockFlowExecutionKeyFactory;
  * @author Ben Hale
  * @author Jeremy Grelle
  */
-public class FlowExecutionImplTests extends TestCase {
+public class FlowExecutionImplTests {
 
 
+	@Test
 	public void testStartAndEnd() {
 		Flow flow = new Flow("flow");
 		new EndState(flow, "end");
@@ -85,6 +93,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(0, mockListener.getFlowNestingLevel());
 	}
 
+	@Test
 	public void testStartAndEndSavedMessages() {
 		Flow flow = new Flow("flow");
 		new EndState(flow, "end");
@@ -106,6 +115,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertNotNull(execution.getFlashScope().get("messagesMemento"));
 	}
 
+	@Test
 	public void testStartAndPause() {
 		Flow flow = new Flow("flow");
 		new State(flow, "state") {
@@ -123,6 +133,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(1, mockListener.getPausedCount());
 	}
 
+	@Test
 	public void testStartWithNullInputMap() {
 		Flow flow = new Flow("flow");
 		new State(flow, "state") {
@@ -145,6 +156,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(1, mockListener.getPausedCount());
 	}
 
+	@Test
 	public void testStartExceptionThrownBeforeFirstSessionCreated() {
 		Flow flow = new Flow("flow");
 		flow.getExceptionHandlerSet().add(new FlowExecutionExceptionHandler() {
@@ -181,6 +193,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStartExceptionThrownByState() {
 		Flow flow = new Flow("flow");
 		State state = new State(flow, "state") {
@@ -200,6 +213,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStartFlowExecutionExceptionThrownByState() {
 		Flow flow = new Flow("flow");
 		final FlowExecutionException e = new FlowExecutionException("flow", "state", "Oops");
@@ -219,6 +233,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStartExceptionThrownByStateHandledByFlowExceptionHandler() {
 		Flow flow = new Flow("flow");
 		StubFlowExecutionExceptionHandler exceptionHandler = new StubFlowExecutionExceptionHandler();
@@ -236,6 +251,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertTrue(exceptionHandler.getHandled());
 	}
 
+	@Test
 	public void testStartExceptionThrownByStateHandledByStateExceptionHandler() {
 		Flow flow = new Flow("flow");
 		flow.getExceptionHandlerSet().add(new StubFlowExecutionExceptionHandler());
@@ -254,6 +270,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertTrue(exceptionHandler.getHandled());
 	}
 
+	@Test
 	public void testExceptionHandledByNestedExceptionHandler() {
 		Flow flow = new Flow("flow");
 		ExceptionThrowingExceptionHandler exceptionHandler = new ExceptionThrowingExceptionHandler(true);
@@ -270,6 +287,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(2, exceptionHandler.getHandleCount());
 	}
 
+	@Test
 	public void testStartCannotCallTwice() {
 		Flow flow = new Flow("flow");
 		new EndState(flow, "end");
@@ -284,6 +302,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testResume() {
 		Flow flow = new Flow("flow");
 		new ViewState(flow, "view", new StubViewFactory());
@@ -300,6 +319,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(2, mockListener.getPausedCount());
 	}
 
+	@Test
 	public void testResumeNotAViewState() {
 		Flow flow = new Flow("flow");
 		new State(flow, "state") {
@@ -323,6 +343,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testResumeAfterEnding() {
 		Flow flow = new Flow("flow");
 		new EndState(flow, "end");
@@ -337,6 +358,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testResumeException() {
 		Flow flow = new Flow("flow");
 		ViewState state = new ViewState(flow, "view", new StubViewFactory()) {
@@ -362,6 +384,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testResumeFlowExecutionException() {
 		Flow flow = new Flow("flow");
 		ViewState state = new ViewState(flow, "view", new StubViewFactory()) {
@@ -387,6 +410,7 @@ public class FlowExecutionImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testExecuteTransition() {
 		Flow flow = new Flow("flow");
 		ViewState state = new ViewState(flow, "view", new StubViewFactory()) {
@@ -409,6 +433,7 @@ public class FlowExecutionImplTests extends TestCase {
 		assertEquals(1, mockListener.getTransitionExecutingCount());
 	}
 
+	@Test
 	public void testRequestContextManagedOnStartAndResume() {
 		Flow flow = new Flow("flow");
 		new ViewState(flow, "view", new StubViewFactory()) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/AbstractModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/AbstractModelTests.java
@@ -15,15 +15,20 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link AbstractModel}.
  */
-public class AbstractModelTests extends TestCase {
+public class AbstractModelTests {
 
+	@Test
 	public void testStringMerge() {
 		AbstractModel obj = new PersistenceContextModel();
 		String child = "child";
@@ -31,6 +36,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("child", obj.merge(child, parent));
 	}
 
+	@Test
 	public void testStringMergeNullParent() {
 		AbstractModel obj = new PersistenceContextModel();
 		String child = "child";
@@ -38,6 +44,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("child", obj.merge(child, parent));
 	}
 
+	@Test
 	public void testStringMergeNullChild() {
 		AbstractModel obj = new PersistenceContextModel();
 		String child = null;
@@ -45,6 +52,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("parent", obj.merge(child, parent));
 	}
 
+	@Test
 	public void testStringMergeNulls() {
 		AbstractModel obj = new PersistenceContextModel();
 		String child = null;
@@ -52,6 +60,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals(null, obj.merge(child, parent));
 	}
 
+	@Test
 	public void testMergeModel() {
 		AttributeModel parent = new AttributeModel("foo", "bar");
 		AttributeModel child = new AttributeModel("foo", null);
@@ -60,6 +69,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("bar", child.getValue());
 	}
 
+	@Test
 	public void testMergeParentCreateCopy() {
 		AttributeModel parent = new AttributeModel("foo", "bar");
 		AttributeModel child = null;
@@ -69,6 +79,7 @@ public class AbstractModelTests extends TestCase {
 		assertNotSame(parent, child);
 	}
 
+	@Test
 	public void testListMergeAddAtEndFalse() {
 		LinkedList<SecuredModel> child = new LinkedList<>();
 		child.add(new SecuredModel("1"));
@@ -88,6 +99,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("foo", result.get(2).getMatch());
 	}
 
+	@Test
 	public void testListMergeAddAtEndTrue() {
 		LinkedList<SecuredModel> child = new LinkedList<>();
 		child.add(new SecuredModel("1"));
@@ -107,6 +119,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("foo", result.get(1).getMatch());
 	}
 
+	@Test
 	public void testListMergeNullParent() {
 		AbstractModel obj = new PersistenceContextModel();
 		LinkedList<SecuredModel> child = new LinkedList<>();
@@ -117,6 +130,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("1", result.get(0).getAttributes());
 	}
 
+	@Test
 	public void testListMergeNullChild() {
 		LinkedList<SecuredModel> child = null;
 		LinkedList<SecuredModel> parent = new LinkedList<>();
@@ -128,6 +142,7 @@ public class AbstractModelTests extends TestCase {
 		assertNotSame(parent.get(0), result.get(0));
 	}
 
+	@Test
 	public void testListMergeNulls() {
 		AbstractModel obj = new PersistenceContextModel();
 		LinkedList<Model> child = null;
@@ -136,6 +151,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals(null, result);
 	}
 
+	@Test
 	public void testCopyModel() {
 		AttributeModel model = new AttributeModel("foo", "bar");
 		FlowModel m = new FlowModel();
@@ -144,6 +160,7 @@ public class AbstractModelTests extends TestCase {
 		assertEquals("bar", copy.getValue());
 	}
 
+	@Test
 	public void testCopyModelNull() {
 		FlowModel m = new FlowModel();
 		AttributeModel copy = (AttributeModel) m.copy(null);

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ActionStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ActionStateModelTests.java
@@ -15,31 +15,40 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link ActionStateModel}.
  */
-public class ActionStateModelTests extends TestCase {
+public class ActionStateModelTests {
 
+	@Test
 	public void testMergeable() {
 		ActionStateModel child = new ActionStateModel("child");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		ActionStateModel child = new ActionStateModel("child");
 		ActionStateModel parent = new ActionStateModel("parent");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		ActionStateModel child = new ActionStateModel("child");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		ActionStateModel child = new ActionStateModel("child");
 		ActionStateModel parent = new ActionStateModel("parent");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/AttributeModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/AttributeModelTests.java
@@ -15,29 +15,37 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link AttributeModel}.
  */
-public class AttributeModelTests extends TestCase {
+public class AttributeModelTests {
 
+	@Test
 	public void testMergeable() {
 		AttributeModel child = new AttributeModel("child", "value");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		AttributeModel child = new AttributeModel("child", "value");
 		AttributeModel parent = new AttributeModel("parent", "value");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		AttributeModel child = new AttributeModel("child", "value");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		AttributeModel child = new AttributeModel("child", "childvalue");
 		AttributeModel parent = new AttributeModel("child", "childvalue");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/BeanImportModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/BeanImportModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link BeanImportModel}.
  */
-public class BeanImportModelTests extends TestCase {
+public class BeanImportModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		BeanImportModel child = new BeanImportModel("child");
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/DecisionStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/DecisionStateModelTests.java
@@ -15,31 +15,39 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link DecisionStateModel}.
  */
-public class DecisionStateModelTests extends TestCase {
+public class DecisionStateModelTests {
 
+	@Test
 	public void testMergeable() {
 		DecisionStateModel child = new DecisionStateModel("child");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		DecisionStateModel child = new DecisionStateModel("child");
 		DecisionStateModel parent = new DecisionStateModel("parent");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		DecisionStateModel child = new DecisionStateModel("child");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		DecisionStateModel child = new DecisionStateModel("child");
 		DecisionStateModel parent = new DecisionStateModel("child");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/EndStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/EndStateModelTests.java
@@ -15,31 +15,39 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link EndStateModel}.
  */
-public class EndStateModelTests extends TestCase {
+public class EndStateModelTests {
 
+	@Test
 	public void testMergeable() {
 		EndStateModel child = new EndStateModel("child");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		EndStateModel child = new EndStateModel("child");
 		EndStateModel parent = new EndStateModel("parent");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		EndStateModel child = new EndStateModel("child");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		EndStateModel child = new EndStateModel("child");
 		EndStateModel parent = new EndStateModel("child");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/EvaluateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/EvaluateModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link EvaluateModel}.
  */
-public class EvaluateModelTests extends TestCase {
+public class EvaluateModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		EvaluateModel child = new EvaluateModel("name");
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ExceptionHandlerModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ExceptionHandlerModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link ExceptionHandlerModel}.
  */
-public class ExceptionHandlerModelTests extends TestCase {
+public class ExceptionHandlerModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		ExceptionHandlerModel child = new ExceptionHandlerModel("child");
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/FlowModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/FlowModelTests.java
@@ -15,27 +15,35 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Unit tests for {@link FlowModel}.
  */
-public class FlowModelTests extends TestCase {
+public class FlowModelTests {
 
+	@Test
 	public void testMergeable() {
 		FlowModel child = new FlowModel();
 		FlowModel parent = new FlowModel();
 		assertTrue(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		FlowModel child = new FlowModel();
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMergeAttributes() {
 		FlowModel child = new FlowModel();
 		FlowModel parent = new FlowModel();
@@ -55,6 +63,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals("type2", child.getAttributes().get(1).getType());
 	}
 
+	@Test
 	public void testMergeSecured() {
 		FlowModel child = new FlowModel();
 		FlowModel parent = new FlowModel();
@@ -66,6 +75,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals("all", child.getSecured().getMatch());
 	}
 
+	@Test
 	public void testMergePersistenceContext() {
 		FlowModel child = new FlowModel();
 		FlowModel parent = new FlowModel();
@@ -74,6 +84,7 @@ public class FlowModelTests extends TestCase {
 		assertNotNull(child.getPersistenceContext());
 	}
 
+	@Test
 	public void testMergeVars() {
 		FlowModel parent = new FlowModel();
 		parent.setVars(asList(new VarModel("name", "value")));
@@ -86,6 +97,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals("value2", child.getVars().get(0).getClassName());
 	}
 
+	@Test
 	public void testMergeMappings() {
 		FlowModel child = new FlowModel();
 		FlowModel parent = new FlowModel();
@@ -113,6 +125,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals(3, child.getInputs().size());
 	}
 
+	@Test
 	public void testMergeOnStart() {
 		FlowModel child = new FlowModel();
 		child.setOnStartActions(asList(new EvaluateModel("expression"), new RenderModel(
@@ -130,6 +143,7 @@ public class FlowModelTests extends TestCase {
 		assertNotNull(((EvaluateModel) child.getOnStartActions().get(0)).getResult());
 	}
 
+	@Test
 	public void testMergeStates() {
 		FlowModel child = new FlowModel();
 		child.setStates(asList(new ViewStateModel("view"), new EndStateModel("end")));
@@ -145,6 +159,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals("jsp", ((ViewStateModel) child.getStates().get(0)).getView());
 	}
 
+	@Test
 	public void testMergeGlobalTransitions() {
 		FlowModel child = new FlowModel();
 		TransitionModel transition1 = new TransitionModel();
@@ -166,6 +181,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals("theend", child.getGlobalTransitions().get(0).getTo());
 	}
 
+	@Test
 	public void testMergeOnEnd() {
 		FlowModel child = new FlowModel();
 		child.setOnEndActions(asList(new EvaluateModel("expression"), new RenderModel("expression"),
@@ -182,6 +198,7 @@ public class FlowModelTests extends TestCase {
 		assertNotNull(((EvaluateModel) child.getOnEndActions().get(0)).getResult());
 	}
 
+	@Test
 	public void testMergeExceptionHandlers() {
 		FlowModel child = new FlowModel();
 		child.setExceptionHandlers(asList(new ExceptionHandlerModel("bean1"),
@@ -194,6 +211,7 @@ public class FlowModelTests extends TestCase {
 		assertEquals(4, child.getExceptionHandlers().size());
 	}
 
+	@Test
 	public void testMergeBeanImports() {
 		FlowModel child = new FlowModel();
 		child.setBeanImports(asList(new BeanImportModel("path1"), new BeanImportModel("path2")));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/IfModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/IfModelTests.java
@@ -15,29 +15,37 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link IfModel}.
  */
-public class IfModelTests extends TestCase {
+public class IfModelTests {
 
+	@Test
 	public void testMergeable() {
 		IfModel child = new IfModel("child", "childthen");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		IfModel child = new IfModel("child", "childthen");
 		IfModel parent = new IfModel("parent", "parentthen");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		IfModel child = new IfModel("child", "childthen");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		IfModel child = new IfModel("child", "childthen");
 		IfModel parent = new IfModel("child", "parentthen");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/InputModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/InputModelTests.java
@@ -15,29 +15,37 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link InputModel}.
  */
-public class InputModelTests extends TestCase {
+public class InputModelTests {
 
+	@Test
 	public void testMergeable() {
 		InputModel child = new InputModel("child", "childvalue");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		InputModel child = new InputModel("child", "childvalue");
 		InputModel parent = new InputModel("parent", "parentvalue");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		InputModel child = new InputModel("child", "childvalue");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		InputModel child = new InputModel("child", "childvalue");
 		InputModel parent = new InputModel("child", "parentvalue");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/OutputModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/OutputModelTests.java
@@ -15,29 +15,37 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link OutputModel}.
  */
-public class OutputModelTests extends TestCase {
+public class OutputModelTests {
 
+	@Test
 	public void testMergeable() {
 		OutputModel child = new OutputModel("child", "childvalue");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		OutputModel child = new OutputModel("child", "childvalue");
 		OutputModel parent = new OutputModel("parent", "parentvalue");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		OutputModel child = new OutputModel("child", "childvalue");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		OutputModel child = new OutputModel("child", "childvalue");
 		OutputModel parent = new OutputModel("child", "parentvalue");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/PersistenceContextModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/PersistenceContextModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link PersistenceContextModel}.
  */
-public class PersistenceContextModelTests extends TestCase {
+public class PersistenceContextModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		PersistenceContextModel child = new PersistenceContextModel();
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/RenderModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/RenderModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link RenderModel}.
  */
-public class RenderModelTests extends TestCase {
+public class RenderModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		RenderModel child = new RenderModel("child");
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SecuredModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SecuredModelTests.java
@@ -15,29 +15,37 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link SecuredModel}.
  */
-public class SecuredModelTests extends TestCase {
+public class SecuredModelTests {
 
+	@Test
 	public void testMergeable() {
 		SecuredModel child = new SecuredModel("child");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		SecuredModel child = new SecuredModel("child");
 		SecuredModel parent = new SecuredModel("parent");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		SecuredModel child = new SecuredModel("child");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		SecuredModel child = new SecuredModel("child");
 		SecuredModel parent = new SecuredModel("child");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SetModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SetModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link SetModel}.
  */
-public class SetModelTests extends TestCase {
+public class SetModelTests {
 
+	@Test
 	public void testNotMergeable() {
 		SetModel child = new SetModel("name", "value");
 		assertFalse(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SubflowStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/SubflowStateModelTests.java
@@ -15,29 +15,38 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link SubflowStateModel}.
  */
-public class SubflowStateModelTests extends TestCase {
+public class SubflowStateModelTests {
 
+	@Test
 	public void testMergeable() {
 		SubflowStateModel child = new SubflowStateModel("child", "flow");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		SubflowStateModel child = new SubflowStateModel("child", "flow");
 		SubflowStateModel parent = new SubflowStateModel("parent", "flow");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		SubflowStateModel child = new SubflowStateModel("child", "flow");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		SubflowStateModel child = new SubflowStateModel("child", null);
 		SubflowStateModel parent = new SubflowStateModel("child", "flow");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/TransitionModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/TransitionModelTests.java
@@ -15,13 +15,18 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link TransitionModel}.
  */
-public class TransitionModelTests extends TestCase {
+public class TransitionModelTests {
 
+	@Test
 	public void testMergeable() {
 		TransitionModel child = new TransitionModel();
 		child.setOn("event");
@@ -30,6 +35,7 @@ public class TransitionModelTests extends TestCase {
 		assertTrue(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testMergeableOnException() {
 		TransitionModel child = new TransitionModel();
 		child.setOnException("expception");
@@ -38,6 +44,7 @@ public class TransitionModelTests extends TestCase {
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		TransitionModel child = new TransitionModel();
 		child.setOn("child");
@@ -46,6 +53,7 @@ public class TransitionModelTests extends TestCase {
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableOnException() {
 		TransitionModel child = new TransitionModel();
 		child.setOnException("child");
@@ -54,11 +62,13 @@ public class TransitionModelTests extends TestCase {
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		TransitionModel child = new TransitionModel();
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		TransitionModel child = new TransitionModel();
 		child.setOn("child");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/VarModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/VarModelTests.java
@@ -15,13 +15,16 @@
  */
 package org.springframework.webflow.engine.model;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit tests for {@link VarModel}.
  */
-public class VarModelTests extends TestCase {
+public class VarModelTests {
 
+	@Test
 	public void testMergeable() {
 		VarModel child = new VarModel("name", "value");
 		assertTrue(child.isMergeableWith(child));

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ViewStateModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/ViewStateModelTests.java
@@ -15,31 +15,41 @@
  */
 package org.springframework.webflow.engine.model;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
 
 /**
  * Unit tests for {@link ViewStateModel}.
  */
-public class ViewStateModelTests extends TestCase {
+public class ViewStateModelTests {
 
+	@Test
 	public void testMergeable() {
 		ViewStateModel child = new ViewStateModel("child");
 		assertTrue(child.isMergeableWith(child));
 	}
 
+	@Test
 	public void testNotMergeable() {
 		ViewStateModel child = new ViewStateModel("child");
 		ViewStateModel parent = new ViewStateModel("parent");
 		assertFalse(child.isMergeableWith(parent));
 	}
 
+	@Test
 	public void testNotMergeableWithNull() {
 		ViewStateModel child = new ViewStateModel("child");
 		assertFalse(child.isMergeableWith(null));
 	}
 
+	@Test
 	public void testMerge() {
 		ViewStateModel child = new ViewStateModel("child");
 		ViewStateModel parent = new ViewStateModel("parent");

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/WebFlowEntityResolverTests.java
@@ -1,13 +1,15 @@
 package org.springframework.webflow.engine.model.builder.xml;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertNotNull;
 
+import org.junit.Test;
 import org.xml.sax.InputSource;
 
-public class WebFlowEntityResolverTests extends TestCase {
+public class WebFlowEntityResolverTests {
 
 	private static final String PUBLIC_ID = "http://www.springframework.org/schema/webflow";
 
+	@Test
 	public void testResolve24() {
 		WebFlowEntityResolver resolver = new WebFlowEntityResolver();
 		InputSource source = resolver.resolveEntity(PUBLIC_ID,
@@ -15,6 +17,7 @@ public class WebFlowEntityResolverTests extends TestCase {
 		assertNotNull(source);
 	}
 
+	@Test
 	public void testResolve20() {
 		WebFlowEntityResolver resolver = new WebFlowEntityResolver();
 		InputSource source = resolver.resolveEntity(PUBLIC_ID,
@@ -22,6 +25,7 @@ public class WebFlowEntityResolverTests extends TestCase {
 		assertNotNull(source);
 	}
 
+	@Test
 	public void testResolveLatest() {
 		WebFlowEntityResolver resolver = new WebFlowEntityResolver();
 		InputSource source = resolver.resolveEntity(PUBLIC_ID,

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/builder/xml/XmlFlowModelBuilderTests.java
@@ -1,7 +1,14 @@
 package org.springframework.webflow.engine.model.builder.xml;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.validation.BindingResult;
@@ -29,16 +36,18 @@ import org.springframework.webflow.execution.factory.StaticFlowExecutionListener
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 
-public class XmlFlowModelBuilderTests extends TestCase {
+public class XmlFlowModelBuilderTests {
 
 	private FlowModelRegistry registry;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		StaticListableBeanFactory beanFactory = new StaticListableBeanFactory();
 		beanFactory.addBean("bean", new Object());
 		registry = new FlowModelRegistryImpl();
 	}
 
+	@Test
 	public void testBuildFlowWithEndState() {
 		ClassPathResource resource = new ClassPathResource("flow-endstate.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -49,6 +58,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("end", flow.getStates().get(0).getId());
 	}
 
+	@Test
 	public void testBuildFlowWithDefaultStartState() {
 		ClassPathResource resource = new ClassPathResource("flow-startstate-default.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -59,6 +69,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("end", flow.getStates().get(0).getId());
 	}
 
+	@Test
 	public void testBuildFlowWithStartStateAttribute() {
 		ClassPathResource resource = new ClassPathResource("flow-startstate-attribute.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -68,6 +79,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("end", flow.getStartStateId());
 	}
 
+	@Test
 	public void testCustomFlowAttribute() {
 		ClassPathResource resource = new ClassPathResource("flow-custom-attribute.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -78,6 +90,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("number", flow.getAttributes().get(1).getName());
 	}
 
+	@Test
 	public void testPersistenceContextFlow() {
 		ClassPathResource resource = new ClassPathResource("flow-persistencecontext.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -87,6 +100,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertNotNull(flow.getPersistenceContext());
 	}
 
+	@Test
 	public void testFlowSecured() {
 		ClassPathResource resource = new ClassPathResource("flow-secured.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -98,6 +112,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("ROLE_USER", secured.getAttributes());
 	}
 
+	@Test
 	public void testFlowSecuredState() {
 		ClassPathResource resource = new ClassPathResource("flow-secured-state.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -109,6 +124,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("ROLE_USER", secured.getAttributes());
 	}
 
+	@Test
 	public void testFlowSecuredTransition() {
 		ClassPathResource resource = new ClassPathResource("flow-secured-transition.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -120,6 +136,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("ROLE_USER", secured.getAttributes());
 	}
 
+	@Test
 	public void testFlowVariable() {
 		ClassPathResource resource = new ClassPathResource("flow-var.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -130,6 +147,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("conversation-foo", flow.getVars().get(1).getName());
 	}
 
+	@Test
 	public void testViewStateVariable() {
 		ClassPathResource resource = new ClassPathResource("flow-viewstate-var.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -139,6 +157,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("foo", ((ViewStateModel) flow.getStates().get(0)).getVars().get(0).getName());
 	}
 
+	@Test
 	public void testViewStateModelBinding() {
 		ClassPathResource resource = new ClassPathResource("flow-viewstate-model-binding.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -152,6 +171,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("customConverter", model.getBinder().getBindings().get(0).getConverter());
 	}
 
+	@Test
 	public void testViewStateRedirect() {
 		ClassPathResource resource = new ClassPathResource("flow-viewstate-redirect.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -161,6 +181,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("true", ((ViewStateModel) flow.getStates().get(0)).getRedirect());
 	}
 
+	@Test
 	public void testViewStatePopup() {
 		ClassPathResource resource = new ClassPathResource("flow-viewstate-popup.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -170,6 +191,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("true", ((ViewStateModel) flow.getStates().get(0)).getPopup());
 	}
 
+	@Test
 	public void testMerge() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-child.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-inheritance-parent.xml", getClass());
@@ -183,6 +205,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("view", flow.getStates().get(0).getId());
 	}
 
+	@Test
 	public void testMergeParentNotFound() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-child.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-inheritance-parent.xml", getClass());
@@ -198,6 +221,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testEvaluateAction() {
 		ClassPathResource resource = new ClassPathResource("flow-action-evaluate-action.xml", getClass());
 		FlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -207,6 +231,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals(4, flow.getOnStartActions().size());
 	}
 
+	@Test
 	public void testStateMerge() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-state-child.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-inheritance-state-parent.xml", getClass());
@@ -219,6 +244,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("otherview", ((ViewStateModel) flow.getStates().get(0)).getView());
 	}
 
+	@Test
 	public void testStateMergeInvalidParentSyntax() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-state-invalid-parent-syntax.xml",
 				getClass());
@@ -235,6 +261,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStateMergeParentFlowNotFound() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-state-child.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-inheritance-state-parent.xml", getClass());
@@ -250,6 +277,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStateMergeParentStateNotFound() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-state-child.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-empty.xml", getClass());
@@ -265,6 +293,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testStateMergeParentStateIncompatable() {
 		ClassPathResource resourceChild = new ClassPathResource("flow-inheritance-state-child-alt.xml", getClass());
 		ClassPathResource resourceParent = new ClassPathResource("flow-inheritance-state-parent.xml", getClass());
@@ -280,6 +309,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseFlowExceptionHandler() {
 		ClassPathResource res = new ClassPathResource("flow-exception-handler.xml", getClass());
 		XmlFlowModelBuilder builder = new XmlFlowModelBuilder(res);
@@ -293,6 +323,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertEquals("foo6", model.getStateById("state5").getExceptionHandlers().get(0).getBean());
 	}
 
+	@Test
 	public void testFormActionValidatorMethod() {
 		ClassPathResource resource = new ClassPathResource("flow-formaction-validatormethod.xml", getClass());
 		XmlFlowModelBuilder builder = new XmlFlowModelBuilder(resource, registry);
@@ -328,6 +359,7 @@ public class XmlFlowModelBuilderTests extends TestCase {
 		assertTrue(((TestBeanValidator) action.getValidator()).getInvoked());
 	}
 
+	@Test
 	public void testParsedFlowValidationHints() {
 		ClassPathResource res = new ClassPathResource("flow-validation-hints.xml", getClass());
 		XmlFlowModelBuilder builder = new XmlFlowModelBuilder(res);

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/registry/DefaultFlowModelHolderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/registry/DefaultFlowModelHolderTests.java
@@ -1,10 +1,13 @@
 package org.springframework.webflow.engine.model.registry;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.util.Collections;
 import java.util.LinkedList;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.Resource;
 import org.springframework.webflow.engine.model.EndStateModel;
 import org.springframework.webflow.engine.model.FlowModel;
@@ -12,21 +15,24 @@ import org.springframework.webflow.engine.model.builder.DefaultFlowModelHolder;
 import org.springframework.webflow.engine.model.builder.FlowModelBuilder;
 import org.springframework.webflow.engine.model.builder.FlowModelBuilderException;
 
-public class DefaultFlowModelHolderTests extends TestCase {
+public class DefaultFlowModelHolderTests {
 	private DefaultFlowModelHolder holder;
 	private FlowModelBuilder builder;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		builder = new SimpleFlowBuilder();
 		holder = new DefaultFlowModelHolder(builder);
 	}
 
+	@Test
 	public void testGetFlowDefinition() {
 		FlowModel flow = holder.getFlowModel();
 		assertNull(flow.getStartStateId());
 		assertEquals("end", flow.getStates().get(0).getId());
 	}
 
+	@Test
 	public void testGetFlowDefinitionWithChangesRefreshed() {
 		FlowModel flow = holder.getFlowModel();
 		holder.refresh();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/model/registry/FlowModelRegistryImplTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/model/registry/FlowModelRegistryImplTests.java
@@ -1,11 +1,15 @@
 package org.springframework.webflow.engine.model.registry;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.Resource;
 import org.springframework.webflow.engine.model.FlowModel;
 
-public class FlowModelRegistryImplTests extends TestCase {
+public class FlowModelRegistryImplTests {
 
 	private FlowModelRegistryImpl registry = new FlowModelRegistryImpl();
 
@@ -13,11 +17,13 @@ public class FlowModelRegistryImplTests extends TestCase {
 
 	private FlowModel barFlow;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		fooFlow = new FlowModel();
 		barFlow = new FlowModel();
 	}
 
+	@Test
 	public void testNoSuchFlowDefinition() {
 		try {
 			registry.getFlowModel("bogus");
@@ -27,11 +33,13 @@ public class FlowModelRegistryImplTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRegisterFlow() {
 		registry.registerFlowModel("foo", new StaticFlowModelHolder(fooFlow));
 		assertEquals(fooFlow, registry.getFlowModel("foo"));
 	}
 
+	@Test
 	public void testRegisterFlowSameIds() {
 		registry.registerFlowModel("foo", new StaticFlowModelHolder(fooFlow));
 		FlowModel newFlow = new FlowModel();
@@ -39,6 +47,7 @@ public class FlowModelRegistryImplTests extends TestCase {
 		assertSame(newFlow, registry.getFlowModel("foo"));
 	}
 
+	@Test
 	public void testRegisterMultipleFlows() {
 		registry.registerFlowModel("foo", new StaticFlowModelHolder(fooFlow));
 		registry.registerFlowModel("bar", new StaticFlowModelHolder(barFlow));
@@ -46,6 +55,7 @@ public class FlowModelRegistryImplTests extends TestCase {
 		assertEquals(barFlow, registry.getFlowModel("bar"));
 	}
 
+	@Test
 	public void testParentHierarchy() {
 		testRegisterMultipleFlows();
 		FlowModelRegistryImpl child = new FlowModelRegistryImpl();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/ActionExecutingViewFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/ActionExecutingViewFactoryTests.java
@@ -1,15 +1,20 @@
 package org.springframework.webflow.engine.support;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.webflow.execution.TestAction;
 import org.springframework.webflow.execution.View;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ActionExecutingViewFactoryTests extends TestCase {
+public class ActionExecutingViewFactoryTests {
 
+	@Test
 	public void testGetView() throws Exception {
 		TestAction action = new TestAction();
 		ActionExecutingViewFactory factory = new ActionExecutingViewFactory(action);
@@ -20,6 +25,7 @@ public class ActionExecutingViewFactoryTests extends TestCase {
 		assertTrue(action.isExecuted());
 	}
 
+	@Test
 	public void testProcessUserEvent() throws IOException {
 		TestAction action = new TestAction();
 		ActionExecutingViewFactory factory = new ActionExecutingViewFactory(action);
@@ -34,6 +40,7 @@ public class ActionExecutingViewFactoryTests extends TestCase {
 		assertEquals("foo", view.getFlowEvent().getId());
 	}
 
+	@Test
 	public void testProcessUserEventButton() throws IOException {
 		TestAction action = new TestAction();
 		ActionExecutingViewFactory factory = new ActionExecutingViewFactory(action);
@@ -48,6 +55,7 @@ public class ActionExecutingViewFactoryTests extends TestCase {
 		assertEquals("foo", view.getFlowEvent().getId());
 	}
 
+	@Test
 	public void testProcessUserEventNoEvent() throws IOException {
 		TestAction action = new TestAction();
 		ActionExecutingViewFactory factory = new ActionExecutingViewFactory(action);

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/ActionTransitionCriteriaTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/ActionTransitionCriteriaTests.java
@@ -15,39 +15,47 @@
  */
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.test.MockAction;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ActionTransitionCriteriaTests extends TestCase {
+public class ActionTransitionCriteriaTests {
 
 	private MockAction action;
 
 	private ActionTransitionCriteria criteria;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		action = new MockAction();
 		criteria = new ActionTransitionCriteria(action);
 	}
 
+	@Test
 	public void testExecuteSuccessResult() {
 		MockRequestContext context = new MockRequestContext();
 		assertTrue(criteria.test(context));
 	}
 
+	@Test
 	public void testExecuteTrueResult() {
 		action.setResultEventId("true");
 		MockRequestContext context = new MockRequestContext();
 		assertTrue(criteria.test(context));
 	}
 
+	@Test
 	public void testExecuteYesResult() {
 		action.setResultEventId("yes");
 		MockRequestContext context = new MockRequestContext();
 		assertTrue(criteria.test(context));
 	}
 
+	@Test
 	public void testExecuteErrorResult() {
 		action.setResultEventId("whatever");
 		MockRequestContext context = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/BeanFactoryVariableValueFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/BeanFactoryVariableValueFactoryTests.java
@@ -1,14 +1,16 @@
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.webflow.TestBean;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class BeanFactoryVariableValueFactoryTests extends TestCase {
+public class BeanFactoryVariableValueFactoryTests {
 	private BeanFactoryVariableValueFactory factory;
 
+	@Test
 	public void testCreateValue() {
 		factory = new BeanFactoryVariableValueFactory(TestBean.class, new DefaultListableBeanFactory());
 		MockRequestContext context = new MockRequestContext();
@@ -16,6 +18,7 @@ public class BeanFactoryVariableValueFactoryTests extends TestCase {
 		assertTrue(value instanceof TestBean);
 	}
 
+	@Test
 	public void testRestoreValue() {
 		factory = new BeanFactoryVariableValueFactory(TestBean.class, new DefaultListableBeanFactory());
 		MockRequestContext context = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/DefaultTargetResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/DefaultTargetResolverTests.java
@@ -1,12 +1,14 @@
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.webflow.engine.Transition;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class DefaultTargetResolverTests extends TestCase {
+public class DefaultTargetResolverTests {
+	@Test
 	public void testResolveState() {
 		DefaultTargetStateResolver resolver = new DefaultTargetStateResolver("mockState");
 		MockRequestContext context = new MockRequestContext();
@@ -14,6 +16,7 @@ public class DefaultTargetResolverTests extends TestCase {
 		assertEquals("mockState", resolver.resolveTargetState(transition, null, context).getId());
 	}
 
+	@Test
 	public void testResolveStateExpression() {
 		DefaultTargetStateResolver resolver = new DefaultTargetStateResolver(new StaticExpression("mockState"));
 		MockRequestContext context = new MockRequestContext();
@@ -21,6 +24,7 @@ public class DefaultTargetResolverTests extends TestCase {
 		assertEquals("mockState", resolver.resolveTargetState(transition, null, context).getId());
 	}
 
+	@Test
 	public void testResolveStateNull() {
 		DefaultTargetStateResolver resolver = new DefaultTargetStateResolver((String) null);
 		MockRequestContext context = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/NotTransitionCriteriaTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/NotTransitionCriteriaTests.java
@@ -15,8 +15,10 @@
  */
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.WildcardTransitionCriteria;
 import org.springframework.webflow.test.MockRequestContext;
 
@@ -25,8 +27,9 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Erwin Vervaet
  */
-public class NotTransitionCriteriaTests extends TestCase {
+public class NotTransitionCriteriaTests {
 
+	@Test
 	public void testNull() {
 		try {
 			new NotTransitionCriteria(null);
@@ -35,6 +38,7 @@ public class NotTransitionCriteriaTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNegation() {
 		assertFalse(new NotTransitionCriteria(WildcardTransitionCriteria.INSTANCE).test(new MockRequestContext()));
 	}

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/TransitionCriteriaChainTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/TransitionCriteriaChainTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.action.EventFactorySupport;
 import org.springframework.webflow.engine.TransitionCriteria;
 import org.springframework.webflow.execution.Action;
@@ -30,20 +33,23 @@ import org.springframework.webflow.test.MockRequestContext;
  * 
  * @author Erwin Vervaet
  */
-public class TransitionCriteriaChainTests extends TestCase {
+public class TransitionCriteriaChainTests {
 
 	private TransitionCriteriaChain chain;
 	private MockRequestContext context;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		chain = new TransitionCriteriaChain();
 		context = new MockRequestContext();
 	}
 
+	@Test
 	public void testEmptyChain() {
 		assertTrue(chain.test(context));
 	}
 
+	@Test
 	public void testAllTrue() {
 		TestTransitionCriteria criteria1 = new TestTransitionCriteria(true);
 		TestTransitionCriteria criteria2 = new TestTransitionCriteria(true);
@@ -57,6 +63,7 @@ public class TransitionCriteriaChainTests extends TestCase {
 		assertTrue(criteria3.tested);
 	}
 
+	@Test
 	public void testWithFalse() {
 		TestTransitionCriteria criteria1 = new TestTransitionCriteria(true);
 		TestTransitionCriteria criteria2 = new TestTransitionCriteria(false);
@@ -70,11 +77,13 @@ public class TransitionCriteriaChainTests extends TestCase {
 		assertFalse(criteria3.tested);
 	}
 
+	@Test
 	public void testCriteriaChainForNoActions() {
 		TransitionCriteria actionChain = TransitionCriteriaChain.criteriaChainFor((Action[]) null);
 		assertTrue(actionChain.test(context));
 	}
 
+	@Test
 	public void testCriteriaChainForActions() {
 		AnnotatedAction[] actions = new AnnotatedAction[] { new AnnotatedAction(new TestAction(true)),
 				new AnnotatedAction(new TestAction(false)) };

--- a/spring-webflow/src/test/java/org/springframework/webflow/engine/support/TransitionExecutingFlowExecutionExceptionHandlerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/engine/support/TransitionExecutingFlowExecutionExceptionHandlerTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.webflow.engine.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.TestException;
 import org.springframework.webflow.action.AbstractAction;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
@@ -42,13 +46,14 @@ import org.springframework.webflow.execution.factory.StaticFlowExecutionListener
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 
-public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestCase {
+public class TransitionExecutingFlowExecutionExceptionHandlerTests {
 
 	Flow flow;
 
 	TransitionableState state;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		flow = new Flow("myFlow");
 		state = new TransitionableState(flow, "state1") {
 			protected void doEnter(RequestControlContext context) {
@@ -58,6 +63,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		state.getTransitionSet().add(new Transition(toState("end")));
 	}
 
+	@Test
 	public void testTransitionExecutorHandlesExceptionExactMatch() {
 		TransitionExecutingFlowExecutionExceptionHandler handler = new TransitionExecutingFlowExecutionExceptionHandler();
 		handler.add(TestException.class, "state");
@@ -69,6 +75,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		assertFalse("Shouldn't handle exception", handler.canHandle(e));
 	}
 
+	@Test
 	public void testTransitionExecutorHandlesExceptionSuperclassMatch() {
 		TransitionExecutingFlowExecutionExceptionHandler handler = new TransitionExecutingFlowExecutionExceptionHandler();
 		handler.add(Exception.class, "state");
@@ -79,6 +86,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		assertTrue("Doesn't handle state exception", handler.canHandle(e));
 	}
 
+	@Test
 	public void testFlowStateExceptionHandlingTransition() {
 		new EndState(flow, "end");
 		TransitionExecutingFlowExecutionExceptionHandler handler = new TransitionExecutingFlowExecutionExceptionHandler();
@@ -99,6 +107,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		assertTrue("Should have ended", !execution.isActive());
 	}
 
+	@Test
 	public void testStateExceptionHandlingTransitionNoSuchState() {
 		TransitionExecutingFlowExecutionExceptionHandler handler = new TransitionExecutingFlowExecutionExceptionHandler();
 		handler.add(TestException.class, "end");
@@ -111,6 +120,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		}
 	}
 
+	@Test
 	public void testStateExceptionHandlingRethrow() {
 		FlowExecution execution = new FlowExecutionImplFactory().createFlowExecution(flow);
 		try {
@@ -121,6 +131,7 @@ public class TransitionExecutingFlowExecutionExceptionHandlerTests extends TestC
 		}
 	}
 
+	@Test
 	public void testStateExceptionHandlingExceptionInEndState() {
 		FlowBuilder builder = new AbstractFlowBuilder() {
 			public void buildStates() throws FlowBuilderException {

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/ConditionalFlowExecutionListenerLoaderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/ConditionalFlowExecutionListenerLoaderTests.java
@@ -15,24 +15,29 @@
  */
 package org.springframework.webflow.execution.factory;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.execution.FlowExecutionListener;
 
 /**
  * Unit tests for {@link ConditionalFlowExecutionListenerLoader}.
  */
-public class ConditionalFlowExecutionListenerLoaderTests extends TestCase {
+public class ConditionalFlowExecutionListenerLoaderTests {
 
 	private FlowExecutionListenerCriteriaFactory criteriaFactory;
 	private ConditionalFlowExecutionListenerLoader loader;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		loader = new ConditionalFlowExecutionListenerLoader();
 		criteriaFactory = new FlowExecutionListenerCriteriaFactory();
 	}
 
+	@Test
 	public void testAddConditionalListener() {
 		FlowExecutionListener listener = new FlowExecutionListener() {};
 		loader.addListener(listener, criteriaFactory.allFlows());
@@ -42,6 +47,7 @@ public class ConditionalFlowExecutionListenerLoaderTests extends TestCase {
 		assertSame(listener, listeners[0]);
 	}
 
+	@Test
 	public void testAddMultipleListeners() {
 		FlowExecutionListener listener1 = new FlowExecutionListener() {};
 		FlowExecutionListener listener2 = new FlowExecutionListener() {};
@@ -54,6 +60,7 @@ public class ConditionalFlowExecutionListenerLoaderTests extends TestCase {
 		assertSame(listener2, listeners[1]);
 	}
 
+	@Test
 	public void testAddListenerButNoMatch() {
 		FlowExecutionListener listener = new FlowExecutionListener() {};
 		loader.addListener(listener, criteriaFactory.flow("bar"));

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/FlowExecutionListenerCriteriaFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/FlowExecutionListenerCriteriaFactoryTests.java
@@ -15,28 +15,32 @@
  */
 package org.springframework.webflow.execution.factory;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.Flow;
 
 /**
  * Unit tests for {@link FlowExecutionListenerCriteriaFactory}.
  */
-public class FlowExecutionListenerCriteriaFactoryTests extends TestCase {
+public class FlowExecutionListenerCriteriaFactoryTests {
 
 	private FlowExecutionListenerCriteriaFactory factory = new FlowExecutionListenerCriteriaFactory();
 
+	@Test
 	public void testAllFlows() {
 		FlowExecutionListenerCriteria c = factory.allFlows();
 		assertEquals(true, c.appliesTo(new Flow("foo")));
 	}
 
+	@Test
 	public void testFlowMatch() {
 		FlowExecutionListenerCriteria c = factory.flow("foo");
 		assertEquals(true, c.appliesTo(new Flow("foo")));
 		assertEquals(false, c.appliesTo(new Flow("baz")));
 	}
 
+	@Test
 	public void testMultipleFlowMatch() {
 		FlowExecutionListenerCriteria c = factory.flows("foo", "bar");
 		assertEquals(true, c.appliesTo(new Flow("foo")));

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/StaticFlowExecutionListenerLoaderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/factory/StaticFlowExecutionListenerLoaderTests.java
@@ -15,29 +15,33 @@
  */
 package org.springframework.webflow.execution.factory;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.execution.FlowExecutionListener;
 
 /**
  * Unit tests for {@link StaticFlowExecutionListenerLoader}.
  */
-public class StaticFlowExecutionListenerLoaderTests extends TestCase {
+public class StaticFlowExecutionListenerLoaderTests {
 
 	private FlowExecutionListenerLoader loader = StaticFlowExecutionListenerLoader.EMPTY_INSTANCE;
 
+	@Test
 	public void testEmptyListenerArray() {
 		assertEquals(0, loader.getListeners(new Flow("foo")).length);
 		assertEquals(0, loader.getListeners(null).length);
 	}
 
+	@Test
 	public void testStaticListener() {
 		final FlowExecutionListener listener1 = new FlowExecutionListener() {};
 		loader = new StaticFlowExecutionListenerLoader(listener1);
 		assertEquals(listener1, loader.getListeners(new Flow("foo"))[0]);
 	}
 
+	@Test
 	public void testStaticListeners() {
 		final FlowExecutionListener listener1 = new FlowExecutionListener() {};
 		final FlowExecutionListener listener2 = new FlowExecutionListener() {};

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/impl/DefaultFlowExecutionRepositoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/impl/DefaultFlowExecutionRepositoryTests.java
@@ -1,10 +1,16 @@
 package org.springframework.webflow.execution.repository.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.conversation.Conversation;
 import org.springframework.webflow.conversation.ConversationException;
 import org.springframework.webflow.conversation.ConversationId;
@@ -13,10 +19,7 @@ import org.springframework.webflow.conversation.ConversationParameters;
 import org.springframework.webflow.conversation.NoSuchConversationException;
 import org.springframework.webflow.conversation.impl.BadlyFormattedConversationIdException;
 import org.springframework.webflow.conversation.impl.SimpleConversationId;
-import org.springframework.webflow.definition.FlowDefinition;
-import org.springframework.webflow.definition.registry.FlowDefinitionConstructionException;
 import org.springframework.webflow.definition.registry.FlowDefinitionLocator;
-import org.springframework.webflow.definition.registry.NoSuchFlowDefinitionException;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.StubViewFactory;
 import org.springframework.webflow.engine.Transition;
@@ -32,13 +35,14 @@ import org.springframework.webflow.execution.repository.NoSuchFlowExecutionExcep
 import org.springframework.webflow.execution.repository.snapshot.SerializedFlowExecutionSnapshotFactory;
 import org.springframework.webflow.test.MockExternalContext;
 
-public class DefaultFlowExecutionRepositoryTests extends TestCase {
+public class DefaultFlowExecutionRepositoryTests {
 	private Flow flow;
 	private ConversationManager conversationManager;
 	private DefaultFlowExecutionRepository repository;
 	FlowExecutionImplFactory executionFactory = new FlowExecutionImplFactory();
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		flow = new Flow("myFlow");
 		ViewState s1 = new ViewState(flow, "state", new StubViewFactory());
 		s1.getTransitionSet().add(new Transition(new DefaultTargetStateResolver("state2")));
@@ -52,12 +56,14 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		executionFactory.setExecutionKeyFactory(repository);
 	}
 
+	@Test
 	public void testParseFlowExecutionKey() {
 		String key = "e12345s54321";
 		FlowExecutionKey k = repository.parseFlowExecutionKey(key);
 		assertEquals(key, k.toString());
 	}
 
+	@Test
 	public void testParseBadlyFormattedFlowExecutionKey() {
 		String key = "e12345";
 		try {
@@ -69,6 +75,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testParseBadlyFormattedFlowExecutionKeyBadContinuationId() {
 		String key = "c12345vaaaa";
 		try {
@@ -80,6 +87,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetLock() {
 		FlowExecutionKey key = repository.parseFlowExecutionKey("e12345s54321");
 		FlowExecutionLock lock = repository.getLock(key);
@@ -87,6 +95,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		lock.unlock();
 	}
 
+	@Test
 	public void testGetLockNoSuchFlowExecution() {
 		FlowExecutionKey key = repository.parseFlowExecutionKey("e99999s54321");
 		try {
@@ -97,6 +106,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testPutFlowExecution() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -109,6 +119,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		assertEquals(execution.getActiveSession().getState().getId(), execution2.getActiveSession().getState().getId());
 	}
 
+	@Test
 	public void testPutFlowExecutionNextSnapshotId() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -126,6 +137,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		assertNotSame(execution.getKey(), execution2.getKey());
 	}
 
+	@Test
 	public void testPutFlowExecutionNoKeyAssigned() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		try {
@@ -136,6 +148,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveFlowExecution() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -150,6 +163,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveKeyNotSet() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		try {
@@ -160,6 +174,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveNoSuchFlowExecution() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -172,6 +187,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testGetKey() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		assertEquals("e12345s1", repository.getKey(execution).toString());
@@ -179,6 +195,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		assertEquals("e12345s3", repository.getKey(execution).toString());
 	}
 
+	@Test
 	public void testUpdate() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -189,6 +206,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		assertEquals("bar", execution2.getActiveSession().getScope().get("foo"));
 	}
 
+	@Test
 	public void testRemove() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -202,6 +220,7 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveAll() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		execution.start(null, new MockExternalContext());
@@ -216,16 +235,19 @@ public class DefaultFlowExecutionRepositoryTests extends TestCase {
 
 	}
 
+	@Test
 	public void testUpdateNothingToDo() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		repository.updateFlowExecutionSnapshot(execution);
 	}
 
+	@Test
 	public void testRemoveNothingToDo() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		repository.removeFlowExecutionSnapshot(execution);
 	}
 
+	@Test
 	public void testRemoveAllSnapshotsNothingToDo() {
 		FlowExecution execution = executionFactory.createFlowExecution(flow);
 		repository.removeAllFlowExecutionSnapshots(execution);

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/impl/SimpleFlowExecutionSnapshotGroupTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/impl/SimpleFlowExecutionSnapshotGroupTests.java
@@ -1,13 +1,16 @@
 package org.springframework.webflow.execution.repository.impl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
 import java.io.Serializable;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.webflow.execution.repository.snapshot.FlowExecutionSnapshot;
 import org.springframework.webflow.execution.repository.snapshot.SnapshotNotFoundException;
 
-public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
+public class SimpleFlowExecutionSnapshotGroupTests {
 
 	private SimpleFlowExecutionSnapshotGroup group = new SimpleFlowExecutionSnapshotGroup();
 
@@ -23,18 +26,21 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 
 	};
 
+	@Test
 	public void testInitialState() {
 		assertEquals(0, group.getSnapshotCount());
 		assertEquals(-1, group.getMaxSnapshots());
 		assertEquals(1, group.nextSnapshotId());
 	}
 
+	@Test
 	public void testGetSnapshot() {
 		Serializable id = group.nextSnapshotId();
 		group.addSnapshot(id, snapshot);
 		assertSame(snapshot, group.getSnapshot(id));
 	}
 
+	@Test
 	public void testGetSnapshotNotFound() {
 		try {
 			group.getSnapshot(group.nextSnapshotId());
@@ -44,11 +50,13 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testNextSnapshotId() {
 		assertEquals(1, group.nextSnapshotId());
 		assertEquals(2, group.nextSnapshotId());
 	}
 
+	@Test
 	public void testAddMaximumReached() {
 		group.setMaxSnapshots(2);
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
@@ -63,6 +71,7 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveSnapshot() {
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
 		group.addSnapshot(group.nextSnapshotId(), snapshot2);
@@ -77,6 +86,7 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testRemoveAllSnapshots() {
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
 		group.addSnapshot(group.nextSnapshotId(), snapshot2);
@@ -85,12 +95,14 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		assertEquals(0, group.getSnapshotCount());
 	}
 
+	@Test
 	public void testUpdateSnapshot() {
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
 		group.updateSnapshot(1, snapshot2);
 		assertSame(snapshot2, group.getSnapshot(1));
 	}
 
+	@Test
 	public void testRemoveSnapshotDoesNotExist() {
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
 		group.removeSnapshot(1);
@@ -99,6 +111,7 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		assertEquals(0, group.getSnapshotCount());
 	}
 
+	@Test
 	public void testRemoveSnapshotsDoesNotExist() {
 		group.addSnapshot(group.nextSnapshotId(), snapshot);
 		group.removeAllSnapshots();
@@ -107,6 +120,7 @@ public class SimpleFlowExecutionSnapshotGroupTests extends TestCase {
 		assertEquals(0, group.getSnapshotCount());
 	}
 
+	@Test
 	public void testUpdateSnapshotDoesNotExist() {
 		assertEquals(0, group.getSnapshotCount());
 		group.updateSnapshot(1, snapshot2);

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/snapshot/SerializedFlowExecutionSnapshotFactoryTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/snapshot/SerializedFlowExecutionSnapshotFactoryTests.java
@@ -1,7 +1,12 @@
 package org.springframework.webflow.execution.repository.snapshot;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.definition.registry.FlowDefinitionLocator;
 import org.springframework.webflow.engine.Flow;
 import org.springframework.webflow.engine.RequestControlContext;
@@ -11,11 +16,12 @@ import org.springframework.webflow.engine.impl.FlowExecutionImplFactory;
 import org.springframework.webflow.execution.FlowExecutionException;
 import org.springframework.webflow.test.MockExternalContext;
 
-public class SerializedFlowExecutionSnapshotFactoryTests extends TestCase {
+public class SerializedFlowExecutionSnapshotFactoryTests {
 	private Flow flow;
 	private SerializedFlowExecutionSnapshotFactory factory;
 	private FlowExecutionImplFactory executionFactory;
 
+	@Before
 	public void setUp() {
 		flow = new Flow("myFlow");
 		new State(flow, "state") {
@@ -28,6 +34,7 @@ public class SerializedFlowExecutionSnapshotFactoryTests extends TestCase {
 		factory = new SerializedFlowExecutionSnapshotFactory(executionFactory, locator);
 	}
 
+	@Test
 	public void testCreateSnapshot() {
 		FlowExecutionImpl flowExecution = (FlowExecutionImpl) executionFactory.createFlowExecution(flow);
 		flowExecution.start(null, new MockExternalContext());

--- a/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/support/CompositeFlowExecutionKeyTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/execution/repository/support/CompositeFlowExecutionKeyTests.java
@@ -15,17 +15,20 @@
  */
 package org.springframework.webflow.execution.repository.support;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
+import org.junit.Test;
 import org.springframework.webflow.conversation.impl.SimpleConversationId;
 
-public class CompositeFlowExecutionKeyTests extends TestCase {
+public class CompositeFlowExecutionKeyTests {
 
+	@Test
 	public void testToString() {
 		CompositeFlowExecutionKey key = new CompositeFlowExecutionKey(new SimpleConversationId("1"), "1");
 		assertEquals("e1s1", key.toString());
 	}
 
+	@Test
 	public void testEquals() {
 		CompositeFlowExecutionKey key = new CompositeFlowExecutionKey(new SimpleConversationId("foo"), "bar");
 		CompositeFlowExecutionKey key2 = new CompositeFlowExecutionKey(new SimpleConversationId("foo"), "bar");

--- a/spring-webflow/src/test/java/org/springframework/webflow/executor/FlowExecutorImplTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/executor/FlowExecutorImplTests.java
@@ -1,8 +1,13 @@
 package org.springframework.webflow.executor;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.context.ExternalContextHolder;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.core.collection.MutableAttributeMap;
@@ -18,7 +23,7 @@ import org.springframework.webflow.test.GeneratedFlowExecutionKey;
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockFlowExecutionKey;
 
-public class FlowExecutorImplTests extends TestCase {
+public class FlowExecutorImplTests {
 	private FlowExecutor flowExecutor;
 
 	// mocks
@@ -29,7 +34,8 @@ public class FlowExecutorImplTests extends TestCase {
 	private FlowExecutionRepository repository;
 	private FlowExecutionLock lock;
 
-	protected void setUp() {
+	@Before
+	public void setUp() {
 		locator = EasyMock.createMock(FlowDefinitionLocator.class);
 		definition = EasyMock.createMock(FlowDefinition.class);
 		factory = EasyMock.createMock(FlowExecutionFactory.class);
@@ -40,6 +46,7 @@ public class FlowExecutorImplTests extends TestCase {
 		flowExecutor = new FlowExecutorImpl(locator, factory, repository);
 	}
 
+	@Test
 	public void testLaunchFlowExecution() {
 		String flowId = "foo";
 		MutableAttributeMap<Object> input = null;
@@ -78,6 +85,7 @@ public class FlowExecutorImplTests extends TestCase {
 		verifyMocks();
 	}
 
+	@Test
 	public void testLaunchFlowExecutionEndsAfterProcessing() {
 		String flowId = "foo";
 		MutableAttributeMap<Object> input = null;
@@ -107,6 +115,7 @@ public class FlowExecutorImplTests extends TestCase {
 		verifyMocks();
 	}
 
+	@Test
 	public void testResumeFlowExecution() {
 		String flowExecutionKey = "12345";
 		MockExternalContext context = new MockExternalContext();
@@ -144,6 +153,7 @@ public class FlowExecutorImplTests extends TestCase {
 
 	}
 
+	@Test
 	public void testResumeFlowExecutionEndsAfterProcessing() {
 		String flowExecutionKey = "12345";
 		MockExternalContext context = new MockExternalContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/el/FlowDependentELResolverTestCase.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/el/FlowDependentELResolverTestCase.java
@@ -1,11 +1,15 @@
 package org.springframework.webflow.expression.el;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
 import java.util.List;
 import javax.el.ELContext;
 import javax.el.ELResolver;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.el.DefaultELContext;
 import org.springframework.binding.expression.el.DefaultELResolver;
 import org.springframework.webflow.engine.ViewState;
@@ -13,36 +17,42 @@ import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
 
-public abstract class FlowDependentELResolverTestCase extends TestCase {
+public abstract class FlowDependentELResolverTestCase {
 
 	protected ELContext context;
 
+	@Before
 	public void setUp() {
 		context = new DefaultELContext(new DefaultELResolver(getCustomResolvers()), null, null);
 	}
 
+	@After
 	public void tearDown() {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testGetType_NoActiveFlow() {
 		assertNull("getType should return null when no flow is active",
 				context.getELResolver().getType(context, null, getBaseVariable()));
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_NoActiveFlow() {
 		assertNull("getValue should return null when no flow is active",
 				context.getELResolver().getValue(context, null, getBaseVariable()));
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_NoActiveFlow() {
 		assertFalse("isReadOnly should return false when no flow is active",
 				context.getELResolver().isReadOnly(context, null, getBaseVariable()));
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_NoActiveFlow() {
 		context.getELResolver().setValue(context, null, getBaseVariable(), null);
 		assertFalse("setValue should be a no-op when no flow is active", context.isPropertyResolved());

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/el/FlowResourceELResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/el/FlowResourceELResolverTests.java
@@ -1,5 +1,9 @@
 package org.springframework.webflow.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -8,6 +12,8 @@ import javax.el.ELResolver;
 import javax.el.PropertyNotFoundException;
 import javax.el.PropertyNotWritableException;
 
+import org.junit.After;
+import org.junit.Test;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.web.context.support.StaticWebApplicationContext;
@@ -18,16 +24,19 @@ import org.springframework.webflow.test.MockRequestContext;
 public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase {
 
 	@Override
+	@After
 	public void tearDown() {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testGetType_BaseVariable() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertEquals(getBaseVariable() + " should have a type of MessageSource", MessageSource.class, context
 				.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_ResolvableCode() {
 		StaticMessageSource ms = new StaticMessageSource();
 		ms.addMessage("foo.bar", Locale.getDefault(), "hello");
@@ -37,6 +46,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 				context.getELResolver().getType(context, ms, "foo.bar"));
 	}
 
+	@Test
 	public void testGetType_InvalidCode() {
 		StaticMessageSource ms = new StaticMessageSource();
 		ms.addMessage("foo.bar", Locale.getDefault(), "hello");
@@ -50,6 +60,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 		}
 	}
 
+	@Test
 	public void testGetValue_BaseVariable() {
 		MockRequestContext requestContext = new MockRequestContext();
 		((Flow) requestContext.getActiveFlow()).setApplicationContext(new StaticWebApplicationContext());
@@ -59,6 +70,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 
 	}
 
+	@Test
 	public void testGetValue_ResolvableCode() {
 		StaticMessageSource ms = new StaticMessageSource();
 		ms.addMessage("foo.bar", Locale.getDefault(), "hello");
@@ -68,6 +80,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 				context.getELResolver().getValue(context, ms, "foo.bar"));
 	}
 
+	@Test
 	public void testGetValue_InvalidCode() {
 		StaticMessageSource ms = new StaticMessageSource();
 		ms.addMessage("foo.bar", Locale.getDefault(), "hello");
@@ -81,12 +94,14 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 		}
 	}
 
+	@Test
 	public void testIsReadOnly_BaseVariable() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue("isReadOnly should return true for the base variable",
 				context.getELResolver().isReadOnly(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testIsReadOnly_MessageSourceBase() {
 		StaticMessageSource ms = new StaticMessageSource();
 
@@ -95,6 +110,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 				.isReadOnly(context, ms, "foo"));
 	}
 
+	@Test
 	public void testSetValue_BaseVariable() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		try {
@@ -105,6 +121,7 @@ public class FlowResourceELResolverTests extends FlowDependentELResolverTestCase
 		}
 	}
 
+	@Test
 	public void testSetValue_MessageSourceBase() {
 		StaticMessageSource ms = new StaticMessageSource();
 		RequestContextHolder.setRequestContext(new MockRequestContext());

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/el/ImplicitFlowVariableELResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/el/ImplicitFlowVariableELResolverTests.java
@@ -1,5 +1,10 @@
 package org.springframework.webflow.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -8,6 +13,7 @@ import java.util.List;
 import javax.el.ELResolver;
 import javax.el.PropertyNotWritableException;
 
+import org.junit.Test;
 import org.springframework.binding.message.MessageContext;
 import org.springframework.util.ClassUtils;
 import org.springframework.webflow.context.ExternalContext;
@@ -39,6 +45,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		vars.add("currentEvent");
 	};
 
+	@Test
 	public void testGetType_RequestParameters() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(ParameterMap.class,
@@ -46,6 +53,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_RequestScope() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(MutableAttributeMap.class,
@@ -53,6 +61,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_FlashScope() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(MutableAttributeMap.class,
@@ -60,6 +69,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_ViewScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -70,6 +80,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_FlowScope() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(MutableAttributeMap.class,
@@ -77,6 +88,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_ConversationScope() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(MutableAttributeMap.class,
@@ -84,6 +96,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_MessageContext() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(MessageContext.class,
@@ -91,6 +104,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_ExternalContext() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(ExternalContext.class,
@@ -98,6 +112,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_FlowExecutionContext() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		assertTrue(ClassUtils.isAssignable(FlowExecutionContext.class,
@@ -105,6 +120,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_FlowExecutionUrl() {
 		MockRequestContext requestContext = new MockRequestContext();
 		((MockFlowExecutionContext) requestContext.getFlowExecutionContext()).setKey(new MockFlowExecutionKey("e1s1"));
@@ -115,6 +131,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_CurrentUser() {
 		MockRequestContext requestContext = new MockRequestContext();
 		((MockExternalContext) requestContext.getExternalContext()).setCurrentUser("jjg");
@@ -125,6 +142,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetType_CurrentEvent() {
 		MockRequestContext requestContext = new MockRequestContext();
 		requestContext.setCurrentEvent(new Event(this, "foo"));
@@ -133,6 +151,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_RequestParameters() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -141,6 +160,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_RequestScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -148,6 +168,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_FlashScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -155,6 +176,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_ViewScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		initView(requestContext);
@@ -163,6 +185,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_FlowScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -170,6 +193,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_ConversationScope() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -178,6 +202,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_MessageContext() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -186,6 +211,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_ExternalContext() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -194,6 +220,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_FlowExecutionContext() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -202,6 +229,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_FlowExecutionUrl() {
 		MockRequestContext requestContext = new MockRequestContext();
 		((MockFlowExecutionContext) requestContext.getFlowExecutionContext()).setKey(new MockFlowExecutionKey("e1s1"));
@@ -211,6 +239,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_CurrentUser() {
 		MockRequestContext requestContext = new MockRequestContext();
 		((MockExternalContext) requestContext.getExternalContext()).setCurrentUser("jjg");
@@ -220,6 +249,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_CurrentEvent() {
 		MockRequestContext requestContext = new MockRequestContext();
 		requestContext.setCurrentEvent(new Event(this, "foo"));
@@ -228,6 +258,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_AllVars() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		Iterator<String> i = vars.iterator();
@@ -237,6 +268,7 @@ public class ImplicitFlowVariableELResolverTests extends FlowDependentELResolver
 		}
 	}
 
+	@Test
 	public void testSetValue_AllVars() {
 		RequestContextHolder.setRequestContext(new MockRequestContext());
 		Iterator<String> i = vars.iterator();

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/el/ScopeSearchingELResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/el/ScopeSearchingELResolverTests.java
@@ -1,15 +1,23 @@
 package org.springframework.webflow.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.el.ELResolver;
 
+import org.junit.Test;
 import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockRequestContext;
 
 public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCase {
 
+	@Test
 	public void testGetType_RequestScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -18,6 +26,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertEquals(MyBean.class, context.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_FlashScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -26,6 +35,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertEquals(MyBean.class, context.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_ViewScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -36,6 +46,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertEquals(MyBean.class, context.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_FlowScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -44,6 +55,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertEquals(MyBean.class, context.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_ConversationScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -52,6 +64,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertEquals(MyBean.class, context.getELResolver().getType(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetType_NotFound() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -59,6 +72,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testGetValue_RequestScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -67,6 +81,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertSame(foo, context.getELResolver().getValue(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetValue_FlashScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -75,6 +90,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertSame(foo, context.getELResolver().getValue(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetValue_ViewScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -84,6 +100,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertSame(foo, context.getELResolver().getValue(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetValue_FlowScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -92,6 +109,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertSame(foo, context.getELResolver().getValue(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetValue_ConversationScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -100,6 +118,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertSame(foo, context.getELResolver().getValue(context, null, getBaseVariable()));
 	}
 
+	@Test
 	public void testGetValue_NotFound() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -107,6 +126,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_RequestScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -116,6 +136,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_FlashScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -125,6 +146,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_ViewScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -135,6 +157,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_FlowScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -144,6 +167,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_ConversationScope() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();
@@ -153,6 +177,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testIsReadOnly_NotFound() {
 		MockRequestContext requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
@@ -160,6 +185,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertFalse(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_RequestScope() {
 		MyBean foo1 = new MyBean();
 		MyBean foo2 = new MyBean();
@@ -171,6 +197,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_FlashScope() {
 		MyBean foo1 = new MyBean();
 		MyBean foo2 = new MyBean();
@@ -182,6 +209,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_ViewScope() {
 		MyBean foo1 = new MyBean();
 		MyBean foo2 = new MyBean();
@@ -194,6 +222,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_FlowScope() {
 		MyBean foo1 = new MyBean();
 		MyBean foo2 = new MyBean();
@@ -205,6 +234,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_ConversationScope() {
 		MyBean foo1 = new MyBean();
 		MyBean foo2 = new MyBean();
@@ -216,6 +246,7 @@ public class ScopeSearchingELResolverTests extends FlowDependentELResolverTestCa
 		assertTrue(context.isPropertyResolved());
 	}
 
+	@Test
 	public void testSetValue_NotFound() {
 		MyBean foo = new MyBean();
 		MockRequestContext requestContext = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/el/WebFlowELExpressionParserTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/el/WebFlowELExpressionParserTests.java
@@ -1,11 +1,13 @@
 package org.springframework.webflow.expression.el;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
 import java.security.Principal;
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
 import org.apache.el.ExpressionFactoryImpl;
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.support.FluentParserContext;
 import org.springframework.context.support.StaticApplicationContext;
@@ -23,9 +25,10 @@ import org.springframework.webflow.execution.TestAction;
 import org.springframework.webflow.test.MockRequestContext;
 import org.springframework.webflow.test.MockRequestControlContext;
 
-public class WebFlowELExpressionParserTests extends TestCase {
+public class WebFlowELExpressionParserTests {
 	private WebFlowELExpressionParser parser = new WebFlowELExpressionParser(new ExpressionFactoryImpl());
 
+	@Test
 	public void testResolveMap() {
 		LocalAttributeMap<Object> map = new LocalAttributeMap<>();
 		map.put("foo", "bar");
@@ -35,6 +38,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals(null, exp2.getValue(map));
 	}
 
+	@Test
 	public void testSetMap() {
 		LocalAttributeMap<Object> map = new LocalAttributeMap<>();
 		map.put("foo", "bar");
@@ -47,6 +51,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("new", exp2.getValue(map));
 	}
 
+	@Test
 	public void testResolveFlowRequestContext() {
 		MockRequestContext context = new MockRequestContext();
 		Expression exp = parser.parseExpression("flowRequestContext",
@@ -54,6 +59,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertSame(context, exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveCurrentUser() {
 		MockRequestContext context = new MockRequestContext();
 		context.getMockExternalContext().setCurrentUser("Keith");
@@ -62,6 +68,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("Keith", ((Principal) exp.getValue(context)).getName());
 	}
 
+	@Test
 	public void testResolveRequestScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getRequestScope().put("foo", "bar");
@@ -69,6 +76,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testSetRequestScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getRequestScope().put("foo", "bar");
@@ -77,6 +85,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("baz", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveFlashScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getFlashScope().put("foo", "bar");
@@ -84,6 +93,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testSetFlashScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getFlashScope().put("foo", "bar");
@@ -92,6 +102,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("baz", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveViewScope() {
 		MockRequestControlContext context = new MockRequestControlContext();
 		ViewState state = new ViewState(context.getRootFlow(), "view", new StubViewFactory());
@@ -101,6 +112,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testSetViewScope() {
 		MockRequestControlContext context = new MockRequestControlContext();
 		ViewState state = new ViewState(context.getRootFlow(), "view", new StubViewFactory());
@@ -111,6 +123,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("baz", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveFlowScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getFlowScope().put("foo", "bar");
@@ -118,6 +131,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testSetFlowScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getFlowScope().put("foo", "bar");
@@ -126,6 +140,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("baz", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveConversationScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getConversationScope().put("foo", "bar");
@@ -133,6 +148,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testSetConversationScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.getConversationScope().put("foo", "bar");
@@ -141,6 +157,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("baz", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveSpringBean() {
 		MockRequestContext context = new MockRequestContext();
 		StaticApplicationContext ac = new StaticApplicationContext();
@@ -150,6 +167,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertSame(ac.getBean("testBean"), exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveAction() {
 		MockRequestContext context = new MockRequestContext();
 		StaticApplicationContext ac = new StaticApplicationContext();
@@ -159,6 +177,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertSame(ac.getBean("action"), exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveMultiAction() {
 		MockRequestContext context = new MockRequestContext();
 		StaticApplicationContext ac = new StaticApplicationContext();
@@ -171,6 +190,7 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("setupForm", action.getMethod());
 	}
 
+	@Test
 	public void testResolveEventAttributes() {
 		MockRequestContext context = new MockRequestContext();
 		LocalAttributeMap<Object> attributes = new LocalAttributeMap<>();
@@ -181,12 +201,14 @@ public class WebFlowELExpressionParserTests extends TestCase {
 		assertEquals("bar", exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveNull() {
 		MockRequestContext context = new MockRequestContext();
 		Expression exp = parser.parseExpression("null", new FluentParserContext().evaluate(RequestContext.class));
 		assertEquals(null, exp.getValue(context));
 	}
 
+	@Test
 	public void testResolveMessage() {
 		MockRequestContext context = new MockRequestContext();
 		StaticApplicationContext ac = new StaticApplicationContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/FlowVariablePropertyAccessorTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/FlowVariablePropertyAccessorTests.java
@@ -15,8 +15,13 @@
  */
 package org.springframework.webflow.expression.spel;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.expression.AccessException;
 import org.springframework.webflow.engine.Flow;
@@ -24,13 +29,14 @@ import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class FlowVariablePropertyAccessorTests extends TestCase {
+public class FlowVariablePropertyAccessorTests {
 
 	private FlowVariablePropertyAccessor accessor = new FlowVariablePropertyAccessor();
 
 	private MockRequestContext requestContext;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
 	}
@@ -39,11 +45,13 @@ public class FlowVariablePropertyAccessorTests extends TestCase {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testFlowRequestContext() throws Exception {
 		assertTrue(accessor.canRead(null, null, "flowRequestContext"));
 		assertEquals(requestContext, accessor.read(null, null, "flowRequestContext").getValue());
 	}
 
+	@Test
 	public void testCurrentUser() throws Exception {
 		MockExternalContext externalContext = (MockExternalContext) requestContext.getExternalContext();
 		externalContext.setCurrentUser("joe");
@@ -51,6 +59,7 @@ public class FlowVariablePropertyAccessorTests extends TestCase {
 		assertEquals(externalContext.getCurrentUser(), accessor.read(null, null, "currentUser").getValue());
 	}
 
+	@Test
 	public void testResourceBundle() throws Exception {
 		Flow flow = (Flow) requestContext.getActiveFlow();
 		flow.setApplicationContext(new StaticApplicationContext());
@@ -60,6 +69,7 @@ public class FlowVariablePropertyAccessorTests extends TestCase {
 				.read(null, null, "resourceBundle").getValue());
 	}
 
+	@Test
 	public void testWrite() throws Exception {
 		assertFalse(accessor.canWrite(null, null, "anyName"));
 		try {

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/ScopeSearchingPropertyAccessorTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/ScopeSearchingPropertyAccessorTests.java
@@ -15,8 +15,11 @@
  */
 package org.springframework.webflow.expression.spel;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.expression.TypedValue;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.webflow.engine.ViewState;
@@ -26,22 +29,25 @@ import org.springframework.webflow.execution.ViewFactory;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ScopeSearchingPropertyAccessorTests extends TestCase {
+public class ScopeSearchingPropertyAccessorTests {
 
 	private ScopeSearchingPropertyAccessor accessor = new ScopeSearchingPropertyAccessor();
 
 	private MockRequestContext requestContext;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		requestContext = new MockRequestContext();
 	}
 
+	@Test
 	public void testGetSpecificTargetClasses() throws Exception {
 		Class<?>[] classes = accessor.getSpecificTargetClasses();
 		assertEquals(1, classes.length);
 		assertEquals(RequestContext.class, classes[0]);
 	}
 
+	@Test
 	public void testGetValue() throws Exception {
 		Object bean = new Object();
 		requestContext.getConversationScope().put("myBean", bean);

--- a/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/WebFlowSpringELExpressionParserTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/expression/spel/WebFlowSpringELExpressionParserTests.java
@@ -15,10 +15,13 @@
  */
 package org.springframework.webflow.expression.spel;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Locale;
 
-import junit.framework.TestCase;
-
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.Expression;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.support.FluentParserContext;
@@ -30,23 +33,24 @@ import org.springframework.webflow.execution.RequestContextHolder;
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class WebFlowSpringELExpressionParserTests extends TestCase {
+public class WebFlowSpringELExpressionParserTests {
 
 	private ExpressionParser parser = new WebFlowSpringELExpressionParser(new SpelExpressionParser());
 
 	private MockRequestContext requestContext;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		requestContext = new MockRequestContext();
 		RequestContextHolder.setRequestContext(requestContext);
 	}
 
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
+	@After
+	public void tearDown() throws Exception {
 		RequestContextHolder.setRequestContext(null);
 	}
 
+	@Test
 	public void testResourceBundleRead() {
 		MockExternalContext externalContext = (MockExternalContext) requestContext.getExternalContext();
 		externalContext.setLocale(Locale.ENGLISH);

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowControllerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowControllerTests.java
@@ -1,15 +1,18 @@
 package org.springframework.webflow.mvc.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.context.servlet.DefaultAjaxHandler;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -26,14 +29,15 @@ import org.springframework.webflow.executor.FlowExecutionResult;
 import org.springframework.webflow.executor.FlowExecutor;
 import org.springframework.webflow.test.MockFlowExecutionKey;
 
-public class FlowControllerTests extends TestCase {
+public class FlowControllerTests {
 	private FlowController controller;
 	private FlowExecutor executor;
 	private MockHttpServletRequest request;
 	private MockHttpServletResponse response;
 	private ServletExternalContext context;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		executor = EasyMock.createMock(FlowExecutor.class);
 		controller = new FlowController();
 		FlowHandlerAdapter handlerAdapter = new FlowHandlerAdapter() {
@@ -58,6 +62,7 @@ public class FlowControllerTests extends TestCase {
 		context = new ServletExternalContext(servletContext, request, response, controller.getFlowUrlHandler());
 	}
 
+	@Test
 	public void testLaunchFlowRequest() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -73,6 +78,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowRequestEndsAfterProcessing() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -92,6 +98,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testResumeFlowRequest() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -110,6 +117,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testResumeFlowRequestEndsAfterProcessing() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -132,6 +140,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExecutionRedirect() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -149,6 +158,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExecutionRedirectAjaxHeaderOpenInPopup() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -172,6 +182,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExecutionRedirectAjaxParameter() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -196,6 +207,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithDefinitionRedirect() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -219,6 +231,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirect() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -237,6 +250,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testDefaultHandleFlowException() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -257,6 +271,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testDefaultHandleNoSuchFlowExecutionException() throws Exception {
 		request.setContextPath("/springtravel");
 		request.setServletPath("/app");
@@ -274,6 +289,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testLaunchFlowWithCustomFlowHandler() throws Exception {
 		final LocalAttributeMap<Object> input = new LocalAttributeMap<>();
 		input.put("bar", "boop");
@@ -309,6 +325,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testHandleFlowOutcomeCustomFlowHandler() throws Exception {
 		final LocalAttributeMap<Object> input = new LocalAttributeMap<>();
 		input.put("bar", "boop");
@@ -352,6 +369,7 @@ public class FlowControllerTests extends TestCase {
 		EasyMock.verify(executor);
 	}
 
+	@Test
 	public void testHandleFlowExceptionCustomFlowHandler() throws Exception {
 		final FlowException flowException = new FlowException("Error") {
 		};

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowHandlerAdapterTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowHandlerAdapterTests.java
@@ -1,14 +1,20 @@
 package org.springframework.webflow.mvc.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
 import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -27,7 +33,7 @@ import org.springframework.webflow.executor.FlowExecutionResult;
 import org.springframework.webflow.executor.FlowExecutor;
 import org.springframework.webflow.test.MockFlowExecutionKey;
 
-public class FlowHandlerAdapterTests extends TestCase {
+public class FlowHandlerAdapterTests {
 	private FlowHandlerAdapter flowHandlerAdapter;
 	private FlowExecutor flowExecutor;
 	private MockHttpServletRequest request;
@@ -39,7 +45,8 @@ public class FlowHandlerAdapterTests extends TestCase {
 	private boolean handleExecutionOutcome;
 	private MockFlashMapManager flashMapManager = new MockFlashMapManager();
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		flowExecutor = EasyMock.createMock(FlowExecutor.class);
 		flowHandlerAdapter = new FlowHandlerAdapter() {
 			protected ServletExternalContext createServletExternalContext(HttpServletRequest request,
@@ -87,6 +94,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		request.setAttribute(DispatcherServlet.FLASH_MAP_MANAGER_ATTRIBUTE, flashMapManager);
 	}
 
+	@Test
 	public void testLaunchFlowRequest() throws Exception {
 		setupRequest("/springtravel", "/app", "/whatever", "GET");
 		flowExecutor.launchExecution("foo", flowInput, context);
@@ -97,6 +105,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowRequestEndsAfterProcessing() throws Exception {
 		setupRequest("/springtravel", "/app", "/whatever", "GET");
 		Map<String, String> parameters = new HashMap<>();
@@ -113,6 +122,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowRequestEndsAfterProcessingAjaxRequest() throws Exception {
 		setupRequest("/springtravel", "/app", "/whatever", "GET");
 		Map<String, String> parameters = new HashMap<>();
@@ -131,6 +141,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testResumeFlowRequest() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "POST");
 		request.addParameter("execution", "12345");
@@ -142,6 +153,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testResumeFlowRequestEndsAfterProcessing() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "POST");
 		request.addParameter("execution", "12345");
@@ -160,6 +172,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testResumeFlowRequestEndsAfterProcessingFlowCommittedResponse() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "POST");
 		request.addParameter("execution", "12345");
@@ -179,6 +192,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExecutionRedirect() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestFlowExecutionRedirect();
@@ -192,6 +206,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithDefinitionRedirect() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		Map<String, String> parameters = new HashMap<>();
@@ -213,6 +228,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalHttpRedirect() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("https://www.paypal.com");
@@ -226,6 +242,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalHttpsRedirect() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("https://www.paypal.com");
@@ -239,6 +256,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectServletRelative() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("servletRelative:bar");
@@ -252,6 +270,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectServletRelativeWithSlash() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("servletRelative:/bar");
@@ -265,6 +284,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectContextRelative() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("contextRelative:bar");
@@ -278,6 +298,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectContextRelativeWithSlash() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("contextRelative:/bar");
@@ -291,6 +312,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectServerRelative() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("serverRelative:bar");
@@ -304,6 +326,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectServerRelativeWithSlash() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		context.requestExternalRedirect("serverRelative:/bar");
@@ -317,6 +340,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testLaunchFlowWithExternalRedirectNotHttp10Compatible() throws Exception {
 		flowHandlerAdapter.setRedirectHttp10Compatible(false);
 		setupRequest("/springtravel", "/app", "/foo", "GET");
@@ -332,6 +356,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testSwf1385DefaultServletExternalRedirect() throws Exception {
 		setupRequest("/springtravel", "/foo", null, "GET");
 		context.requestExternalRedirect("/bar");
@@ -345,6 +370,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testSwf1385DefaultServletExternalRedirectDeviation() throws Exception {
 		// Deviation from the default case:
 		// In some containers the default behavior can be switched so that the contents of the URI after
@@ -361,6 +387,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testSwf1385DefaultServletExternalRedirectServletRelative() throws Exception {
 		setupRequest("/springtravel", "/foo", null, "GET");
 		context.requestExternalRedirect("/bar");
@@ -374,6 +401,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testExternalRedirectServletRelativeWithDefaultServletMapping() throws Exception {
 		setupRequest("/springtravel", "/foo", null, "GET");
 		context.requestExternalRedirect("servletRelative:bar");
@@ -387,6 +415,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testRemoteHost() throws Exception {
 		assertFalse(flowHandlerAdapter.isRemoteHost("https://url.somewhere.com"));
 		assertFalse(flowHandlerAdapter.isRemoteHost("/path"));
@@ -400,6 +429,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 
 	}
 
+	@Test
 	public void testDefaultHandleFlowException() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		Map<String, String> parameters = new HashMap<>();
@@ -418,6 +448,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testDefaultHandleNoSuchFlowExecutionException() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		request.addParameter("execution", "12345");
@@ -430,6 +461,7 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testDefaultHandleNoSuchFlowExecutionExceptionAjaxRequest() throws Exception {
 		setupRequest("/springtravel", "/app", "/foo", "GET");
 		request.addParameter("execution", "12345");
@@ -444,11 +476,13 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testHandleFlowOutcomeCustomFlowHandler() throws Exception {
 		doHandleFlowServletRedirectOutcome();
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testHandleFlowExceptionCustomFlowHandler() throws Exception {
 		handleException = true;
 		final FlowException flowException = new FlowException("Error") {
@@ -461,11 +495,13 @@ public class FlowHandlerAdapterTests extends TestCase {
 		EasyMock.verify(flowExecutor);
 	}
 
+	@Test
 	public void testHandleFlowServletRedirectOutcomeWithoutFlash() throws Exception {
 		doHandleFlowServletRedirectOutcome();
 		assertNull(flashMapManager.getFlashMap());
 	}
 
+	@Test
 	public void testHandleFlowServletRedirectOutcomeWithFlash() throws Exception {
 		flowHandlerAdapter.setSaveOutputToFlashScopeOnRedirect(true);
 		doHandleFlowServletRedirectOutcome();

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowHandlerMappingTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/FlowHandlerMappingTests.java
@@ -1,10 +1,15 @@
 package org.springframework.webflow.mvc.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
@@ -17,9 +22,10 @@ import org.springframework.webflow.definition.StateDefinition;
 import org.springframework.webflow.definition.registry.FlowDefinitionRegistryImpl;
 import org.springframework.webflow.execution.FlowExecutionOutcome;
 
-public class FlowHandlerMappingTests extends TestCase {
+public class FlowHandlerMappingTests {
 	private FlowHandlerMapping mapping = new FlowHandlerMapping();
 
+	@Before
 	public void setUp() {
 		FlowDefinitionRegistryImpl registry = new FlowDefinitionRegistryImpl();
 		registry.registerFlowDefinition(new FlowDefinitionImpl());
@@ -31,6 +37,7 @@ public class FlowHandlerMappingTests extends TestCase {
 		mapping.setApplicationContext(context);
 	}
 
+	@Test
 	public void testGetHandler() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setContextPath("/springtravel");
@@ -43,6 +50,7 @@ public class FlowHandlerMappingTests extends TestCase {
 		assertEquals("flow", handler.getFlowId());
 	}
 
+	@Test
 	public void testGetHandlerCustomFlowHandler() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setContextPath("/springtravel");
@@ -57,6 +65,7 @@ public class FlowHandlerMappingTests extends TestCase {
 		assertTrue(handler instanceof CustomFlowHandler);
 	}
 
+	@Test
 	public void testGetHandlerNoHandler() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setContextPath("/springtravel");
@@ -68,6 +77,7 @@ public class FlowHandlerMappingTests extends TestCase {
 		assertNull(chain);
 	}
 
+	@Test
 	public void testGetHandlerNullFlowId() throws Exception {
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		HandlerExecutionChain chain = mapping.getHandler(request);

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/ServletMvcViewTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/servlet/ServletMvcViewTests.java
@@ -1,5 +1,9 @@
 package org.springframework.webflow.mvc.servlet;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.security.Principal;
 import java.util.Calendar;
 import java.util.Date;
@@ -8,8 +12,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
@@ -19,12 +22,13 @@ import org.springframework.webflow.mvc.view.AbstractMvcView;
 import org.springframework.webflow.test.MockFlowExecutionKey;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class ServletMvcViewTests extends TestCase {
+public class ServletMvcViewTests {
 
 	private boolean renderCalled;
 
 	private Map<String, ?> model;
 
+	@Test
 	public void testRender() throws Exception {
 		MockRequestContext context = new MockRequestContext();
 		context.getRequestScope().put("foo", "bar");

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/AbstractBindingModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/AbstractBindingModelTests.java
@@ -1,13 +1,18 @@
 package org.springframework.webflow.mvc.view;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.beans.PropertyEditor;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.converters.StringToObject;
 import org.springframework.binding.convert.service.DefaultConversionService;
 import org.springframework.binding.expression.Expression;
@@ -23,7 +28,7 @@ import org.springframework.webflow.TestBean;
 import org.springframework.webflow.engine.builder.BinderConfiguration;
 import org.springframework.webflow.engine.builder.BinderConfiguration.Binding;
 
-public abstract class AbstractBindingModelTests extends TestCase {
+public abstract class AbstractBindingModelTests {
 
 	BindingModel model;
 	DefaultMessageContext messages;
@@ -31,6 +36,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 	TestBean testBean;
 	ExpressionParser expressionParser;
 
+	@Before
 	public void setUp() {
 		testBean = new TestBean();
 		messages = new DefaultMessageContext();
@@ -41,6 +47,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 
 	protected abstract ExpressionParser getExpressionParser();
 
+	@Test
 	public void testInitialState() {
 		assertEquals(0, model.getErrorCount());
 		assertEquals(0, model.getFieldErrorCount());
@@ -52,21 +59,25 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals(String.class, model.getFieldType("datum1"));
 	}
 
+	@Test
 	public void testGetValue() {
 		testBean.datum1 = "test";
 		assertEquals("test", model.getFieldValue("datum1"));
 	}
 
+	@Test
 	public void testGetConvertedValue() {
 		testBean.datum2 = 3;
 		assertEquals("3", model.getFieldValue("datum2"));
 	}
 
+	@Test
 	public void testGetRawValue() {
 		testBean.datum2 = 3;
 		assertEquals(3, model.getRawFieldValue("datum2"));
 	}
 
+	@Test
 	public void testGetFieldValueConvertedWithCustomConverter() {
 		testBean.datum2 = 3;
 		conversionService.addConverter("customConverter", new StringToObject(Integer.class) {
@@ -84,6 +95,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals("$3", model.getFieldValue("datum2"));
 	}
 
+	@Test
 	public void testGetFieldValueError() {
 		Map<String, String> source = new HashMap<>();
 		source.put("datum2", "bogus");
@@ -110,6 +122,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals(0, model.getFieldErrorCount());
 	}
 
+	@Test
 	public void testGetFieldError() {
 		messages.addMessage(new MessageBuilder().source("datum2").error().defaultText("Error").build());
 		assertEquals(1, model.getErrorCount());
@@ -129,6 +142,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals(error, error2);
 	}
 
+	@Test
 	public void testGetFieldErrorsWildcard() {
 		messages.addMessage(new MessageBuilder().source("datum2").error().defaultText("Error").build());
 		assertEquals(1, model.getFieldErrorCount("da*"));
@@ -139,6 +153,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals("Error", error.getDefaultMessage());
 	}
 
+	@Test
 	public void testFindPropertyEditor() {
 		PropertyEditor editor = model.findEditor("datum2", Integer.class);
 		assertNotNull(editor);
@@ -146,6 +161,7 @@ public abstract class AbstractBindingModelTests extends TestCase {
 		assertEquals("0", editor.getAsText());
 	}
 
+	@Test
 	public void testNestedPath() {
 		model = new BindingModel("nestedPathBean", new NestedPathBean(), expressionParser, conversionService, messages);
 		model.pushNestedPath("nestedBean");

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/AjaxTiles3ViewTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/AjaxTiles3ViewTests.java
@@ -1,9 +1,12 @@
 package org.springframework.webflow.mvc.view;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
 import org.apache.tiles.Attribute;
 import org.apache.tiles.AttributeContext;
 import org.apache.tiles.Definition;
@@ -14,7 +17,8 @@ import org.apache.tiles.request.ApplicationContext;
 import org.apache.tiles.request.Request;
 import org.apache.tiles.request.servlet.ServletRequest;
 import org.apache.tiles.request.servlet.wildcard.WildcardServletApplicationContext;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.context.servlet.DefaultAjaxHandler;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -23,8 +27,7 @@ import org.springframework.web.context.support.StaticWebApplicationContext;
 import org.springframework.web.servlet.support.RequestContext;
 import org.springframework.web.servlet.view.tiles3.TilesConfigurer;
 
-
-public class AjaxTiles3ViewTests extends TestCase {
+public class AjaxTiles3ViewTests {
 
 	private AjaxTiles3View ajaxTilesView;
 
@@ -35,7 +38,8 @@ public class AjaxTiles3ViewTests extends TestCase {
 	private MockServletContext servletContext;
 
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 
 		servletContext = new MockServletContext("/org/springframework/webflow/mvc/view/");
 		request = new MockHttpServletRequest(servletContext);
@@ -59,6 +63,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		ajaxTilesView.setApplicationContext(wac);
 	}
 
+	@Test
 	public void testFullPageRendering() throws Exception {
 		setupStaticWebApplicationContext();
 		ajaxTilesView.setUrl("search");
@@ -67,6 +72,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/layout.jsp", response.getForwardedUrl());
 	}
 
+	@Test
 	public void testAjaxRequestNoFragments() throws Exception {
 		setupStaticWebApplicationContext();
 		request.addHeader("Accept", DefaultAjaxHandler.AJAX_ACCEPT_CONTENT_TYPE);
@@ -76,6 +82,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/layout.jsp", response.getForwardedUrl());
 	}
 
+	@Test
 	public void testRenderFragment_Template() throws Exception {
 		setupStaticWebApplicationContext();
 		request.addHeader("Accept", DefaultAjaxHandler.AJAX_ACCEPT_CONTENT_TYPE);
@@ -86,6 +93,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/searchResults.jsp", response.getForwardedUrl());
 	}
 
+	@Test
 	public void testRenderFragment_Definition() throws Exception {
 		setupStaticWebApplicationContext();
 		request.addHeader("Accept", DefaultAjaxHandler.AJAX_ACCEPT_CONTENT_TYPE);
@@ -96,6 +104,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/search.jsp", response.getForwardedUrl());
 	}
 
+	@Test
 	public void testRenderFragment_CascadedAttribute() throws Exception {
 		setupStaticWebApplicationContext();
 		request.addHeader("Accept", DefaultAjaxHandler.AJAX_ACCEPT_CONTENT_TYPE);
@@ -106,6 +115,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/searchNavigation.jsp", response.getForwardedUrl());
 	}
 
+	@Test
 	public void testRenderFragment_InheritCascadedAttribute() throws Exception {
 		ApplicationContext tilesAppContext = new WildcardServletApplicationContext(servletContext);
 		Request tilesRequest = new ServletRequest(tilesAppContext, request, response);
@@ -121,6 +131,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertTrue(AttributeTestingPreparer.invoked);
 	}
 
+	@Test
 	public void testRenderFragment_DynamicAttribute() throws Exception {
 		ApplicationContext tilesAppContext = new WildcardServletApplicationContext(servletContext);
 		Request tilesRequest = new ServletRequest(tilesAppContext, request, response);
@@ -134,6 +145,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		container.endContext(tilesRequest);
 	}
 
+	@Test
 	public void testRenderFragment_Multiple() throws Exception {
 		setupStaticWebApplicationContext();
 		request.addHeader("Accept", DefaultAjaxHandler.AJAX_ACCEPT_CONTENT_TYPE);
@@ -146,6 +158,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertEquals("/WEB-INF/searchNavigation.jsp", response.getIncludedUrls().get(1));
 	}
 
+	@Test
 	public void testFlattenAttributeMap() throws Exception {
 		ApplicationContext tilesAppContext = new WildcardServletApplicationContext(servletContext);
 		Request tilesRequest = new ServletRequest(tilesAppContext, request, response);
@@ -159,6 +172,7 @@ public class AjaxTiles3ViewTests extends TestCase {
 		assertNotNull(resultMap.get("searchResults"));
 	}
 
+	@Test
 	public void testGetRenderFragments() throws Exception {
 		Map<String, Object> model = new HashMap<>();
 		request.setParameter("fragments", "f1,f2,  f3");

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/BindingModelSwf1370Tests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/BindingModelSwf1370Tests.java
@@ -1,10 +1,12 @@
 package org.springframework.webflow.mvc.view;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.convert.ConversionService;
 import org.springframework.binding.convert.service.DefaultConversionService;
 import org.springframework.binding.message.DefaultMessageContext;
@@ -16,18 +18,20 @@ import org.springframework.webflow.expression.spel.WebFlowSpringELExpressionPars
  * Test harness based on: https://jira.springframework.org/browse/SWF-1370
  * 
  */
-public class BindingModelSwf1370Tests extends TestCase {
+public class BindingModelSwf1370Tests {
 
 	private ConversionService conversionService;
 	private ConverterRegistry converterRegistry;
 	private WebFlowSpringELExpressionParser expressionParser;
 
+	@Before
 	public void setUp() {
 		conversionService = new DefaultConversionService();
 		expressionParser = new WebFlowSpringELExpressionParser(new SpelExpressionParser(), conversionService);
 		converterRegistry = (ConverterRegistry) conversionService.getDelegateConversionService();
 	}
 
+	@Test
 	public void testGetFieldValueWithInvalidBeanWrapperExpression() throws Exception {
 		Question question = new Question();
 		converterRegistry.addConverter(new QuestionConverter(question));

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/MvcViewTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/MvcViewTests.java
@@ -1,5 +1,12 @@
 package org.springframework.webflow.mvc.view;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -14,8 +21,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.binding.convert.converters.StringToDate;
 import org.springframework.binding.convert.service.DefaultConversionService;
 import org.springframework.binding.convert.service.GenericConversionService;
@@ -47,12 +53,13 @@ import org.springframework.webflow.test.MockRequestContext;
 import org.springframework.webflow.test.MockRequestControlContext;
 import org.springframework.webflow.validation.WebFlowMessageCodesResolver;
 
-public class MvcViewTests extends TestCase {
+public class MvcViewTests {
 
 	private boolean renderCalled;
 
 	private Map<String, ?> model;
 
+	@Test
 	public void testRender() throws Exception {
 		MockRequestControlContext context = new MockRequestControlContext();
 		context.setCurrentState(new ViewState(context.getRootFlow(), "test", new StubViewFactory()));
@@ -82,6 +89,7 @@ public class MvcViewTests extends TestCase {
 		assertNull(model.get(BindingResult.MODEL_KEY_PREFIX + "bindBean"));
 	}
 
+	@Test
 	public void testRenderNoKey() throws Exception {
 		MockRequestControlContext context = new MockRequestControlContext();
 		EndState endState = new EndState(context.getRootFlow(), "end");
@@ -112,6 +120,7 @@ public class MvcViewTests extends TestCase {
 		assertNull(model.get(BindingResult.MODEL_KEY_PREFIX + "bindBean"));
 	}
 
+	@Test
 	public void testRenderWithBindingModel() throws Exception {
 		MockRequestControlContext context = new MockRequestControlContext();
 		context.setCurrentState(new ViewState(context.getRootFlow(), "test", new StubViewFactory()));
@@ -137,6 +146,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals("2008-01-01", bm.getFieldValue("dateProperty"));
 	}
 
+	@Test
 	public void testResumeNoEvent() {
 		MockRequestContext context = new MockRequestContext();
 		context.getMockExternalContext().setNativeContext(new MockServletContext());
@@ -151,6 +161,7 @@ public class MvcViewTests extends TestCase {
 		assertNull(view.getFlowEvent());
 	}
 
+	@Test
 	public void testResumeEventNoModelBinding() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -166,6 +177,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals("submit", view.getFlowEvent().getId());
 	}
 
+	@Test
 	public void testResumeEventModelBinding() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -221,6 +233,7 @@ public class MvcViewTests extends TestCase {
 		assertFalse(bindBean.validationMethodInvoked);
 	}
 
+	@Test
 	public void testResumeEventBindingErrors() throws IOException {
 		MockRequestControlContext context = new MockRequestControlContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -250,6 +263,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals("bogus 2", bm.getFieldValue("dateProperty"));
 	}
 
+	@Test
 	public void testResumeEventNoModelInScope() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -293,6 +307,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals("submit", view.getFlowEvent().getId());
 	}
 
+	@Test
 	public void testResumeEventBindingErrorsRedirectAfterPost() throws Exception {
 		MockRequestControlContext context = new MockRequestControlContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -344,6 +359,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals("bogus 2", bm.getFieldValue("dateProperty"));
 	}
 
+	@Test
 	public void testResumeEventBindingErrorsRedirectToReplicatedSessionAfterPost() throws Exception {
 		MockRequestControlContext context = new MockRequestControlContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -417,6 +433,7 @@ public class MvcViewTests extends TestCase {
 		return restoredState;
 	}
 
+	@Test
 	public void testResumeEventModelBindingAllowedFields() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -451,6 +468,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals(null, bindBean.getBeanProperty().getName());
 	}
 
+	@Test
 	public void testResumeEventModelBindingCustomConverter() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -484,6 +502,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals(cal.getTime(), bindBean.getDateProperty());
 	}
 
+	@Test
 	public void testResumeEventModelBindingFieldMarker() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -505,6 +524,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals(false, bindBean.getBooleanProperty());
 	}
 
+	@Test
 	public void testResumeEventModelBindingFieldMarkerFieldPresent() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -528,6 +548,7 @@ public class MvcViewTests extends TestCase {
 		assertEquals(true, bindBean.getBooleanProperty());
 	}
 
+	@Test
 	public void testResumeEventModelBindAndValidate() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -554,6 +575,7 @@ public class MvcViewTests extends TestCase {
 		assertTrue(bindBean.validationMethodInvoked);
 	}
 
+	@Test
 	public void testResumeEventModelBindAndValidateDefaultValidatorFallback() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -580,6 +602,7 @@ public class MvcViewTests extends TestCase {
 		assertTrue(bindBean.validationMethodInvoked);
 	}
 
+	@Test
 	public void testResumeEventModelValidateOnBindingErrors() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -604,6 +627,7 @@ public class MvcViewTests extends TestCase {
 		assertTrue(bindBean.validationMethodInvoked);
 	}
 
+	@Test
 	public void testResumeEventModelNoValidateOnBindingErrors() {
 		MockRequestContext context = new MockRequestContext();
 		context.putRequestParameter("_eventId", "submit");
@@ -629,6 +653,7 @@ public class MvcViewTests extends TestCase {
 		assertFalse(bindBean.validationMethodInvoked);
 	}
 
+	@Test
 	public void testResumeEventStringValidationHint() {
 		StubSmartValidator validator = new StubSmartValidator();
 		MockRequestContext context = new MockRequestContext();
@@ -659,6 +684,7 @@ public class MvcViewTests extends TestCase {
 		assertTrue(validator.invoked);
 	}
 
+	@Test
 	public void testResumeEventObjectArrayValidationHint() {
 		StubSmartValidator validator = new StubSmartValidator();
 		MockRequestContext context = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/SpringBeanBindingModelTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/mvc/view/SpringBeanBindingModelTests.java
@@ -1,7 +1,11 @@
 package org.springframework.webflow.mvc.view;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import java.beans.PropertyEditor;
 
+import org.junit.Test;
 import org.springframework.binding.expression.ExpressionParser;
 import org.springframework.binding.expression.beanwrapper.BeanWrapperExpressionParser;
 
@@ -12,6 +16,7 @@ public class SpringBeanBindingModelTests extends AbstractBindingModelTests {
 	}
 
 	// See SWF-1132
+	@Test
 	public void testFindPropertyEditorForUndeterminableType() {
 		PropertyEditor editor = model.findEditor("emptyMap['foo']", null);
 		assertNull(editor);
@@ -19,6 +24,7 @@ public class SpringBeanBindingModelTests extends AbstractBindingModelTests {
 
 	// BeanWrapper-based EL does not accept result type hints.
 	// Hence it requires a conversion service.
+	@Test
 	public void testGetFieldValueNonStringNoConversionService() {
 		model = new BindingModel("testBean", testBean, getExpressionParser(), null, messages);
 		testBean.datum2 = 3;

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/AbstractFlowManagedPersistenceIntegrationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/AbstractFlowManagedPersistenceIntegrationTests.java
@@ -2,8 +2,8 @@ package org.springframework.webflow.persistence;
 
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
@@ -22,7 +22,7 @@ import org.springframework.webflow.execution.factory.StaticFlowExecutionListener
 import org.springframework.webflow.test.MockExternalContext;
 import org.springframework.webflow.test.MockFlowBuilderContext;
 
-public abstract class AbstractFlowManagedPersistenceIntegrationTests extends TestCase {
+public abstract class AbstractFlowManagedPersistenceIntegrationTests {
 
 	private FlowExecutionListener persistenceListener;
 
@@ -34,7 +34,8 @@ public abstract class AbstractFlowManagedPersistenceIntegrationTests extends Tes
 		return dataSource;
 	}
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		initDataSource();
 		populateDataBase();
 		persistenceListener = createFlowExecutionListener();
@@ -72,6 +73,7 @@ public abstract class AbstractFlowManagedPersistenceIntegrationTests extends Tes
 		flowExecution = factory.createFlowExecution(rootFlow);
 	}
 
+	@Test
 	public void testFlowWithSubflow() {
 		MockExternalContext context = new MockExternalContext();
 		flowExecution.start(null, context);
@@ -81,6 +83,7 @@ public abstract class AbstractFlowManagedPersistenceIntegrationTests extends Tes
 		flowExecution.resume(context);
 	}
 
+	@Test
 	public void testManagedFlowWithUnmanagedSubflow() {
 		MockExternalContext context = new MockExternalContext();
 		flowExecution.start(null, context);

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/AbstractPersistenceContextPropagationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/AbstractPersistenceContextPropagationTests.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -30,7 +34,7 @@ import org.springframework.webflow.execution.FlowSession;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
 
-public abstract class AbstractPersistenceContextPropagationTests extends TestCase {
+public abstract class AbstractPersistenceContextPropagationTests {
 
 	private MockRequestContext requestContext;
 
@@ -40,7 +44,8 @@ public abstract class AbstractPersistenceContextPropagationTests extends TestCas
 		return jdbcTemplate;
 	}
 
-	protected final void setUp() throws Exception {
+	@Before
+	public final void setUp() throws Exception {
 		requestContext = new MockRequestContext();
 		DataSource dataSource = createDataSource();
 		jdbcTemplate = new JdbcTemplate(dataSource);
@@ -48,6 +53,7 @@ public abstract class AbstractPersistenceContextPropagationTests extends TestCas
 		setUpResources(dataSource);
 	}
 
+	@Test
 	public void testSessionStarting_NoPc_ParentPc() {
 		MockFlowSession parentSession = newFlowSession(true, null);
 		MockFlowSession childSession = newFlowSession(false, parentSession);
@@ -61,6 +67,7 @@ public abstract class AbstractPersistenceContextPropagationTests extends TestCas
 		assertSessionNotInScope(childSession);
 	}
 
+	@Test
 	public void testSessionStarting_Pc_ParentPc() {
 		MockFlowSession parentSession = newFlowSession(true, null);
 		MockFlowSession childSession = newFlowSession(true, parentSession);
@@ -76,6 +83,7 @@ public abstract class AbstractPersistenceContextPropagationTests extends TestCas
 				childSession.getScope().get("persistenceContext"));
 	}
 
+	@Test
 	public void testSessionEnd_Pc_NoParentPc() {
 		MockFlowSession parentSession = newFlowSession(false, null);
 		MockFlowSession childSession = newFlowSession(true, parentSession);
@@ -97,6 +105,7 @@ public abstract class AbstractPersistenceContextPropagationTests extends TestCas
 		assertCommitState(false, true);
 	}
 
+	@Test
 	public void testSessionEnd_Pc_ParentPc() {
 		MockFlowSession parentSession = newFlowSession(true, null);
 		MockFlowSession childSession = newFlowSession(true, parentSession);

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernateFlowExecutionListenerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernateFlowExecutionListenerTests.java
@@ -15,10 +15,19 @@
  */
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import javax.sql.DataSource;
 
 import org.hibernate.Hibernate;
 import org.hibernate.Session;
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -27,18 +36,15 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.webflow.engine.EndState;
 import org.springframework.webflow.execution.FlowExecutionException;
-import org.springframework.webflow.persistence.HibernateHandler.SessionCallback;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
-
-import junit.framework.TestCase;
 
 /**
  * Tests for {@link HibernateFlowExecutionListener}
  *
  * @author Ben Hale
  */
-public class HibernateFlowExecutionListenerTests extends TestCase {
+public class HibernateFlowExecutionListenerTests {
 
 	private HibernateHandler hibernate;
 
@@ -46,7 +52,8 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 
 	private HibernateFlowExecutionListener hibernateListener;
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		DataSource dataSource = getDataSource();
 		populateDataBase(dataSource);
 		jdbcTemplate = new JdbcTemplate(dataSource);
@@ -54,6 +61,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		hibernateListener = new HibernateFlowExecutionListener(hibernate.getSessionFactory(), hibernate.getTransactionManager());
 	}
 
+	@Test
 	public void testSameSession() {
 		MockRequestContext context = new MockRequestContext();
 		MockFlowSession flowSession = new MockFlowSession();
@@ -77,6 +85,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testFlowNotAPersistenceContext() {
 		MockRequestContext context = new MockRequestContext();
 		MockFlowSession flowSession = new MockFlowSession();
@@ -84,6 +93,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testFlowCommitsInSingleRequest() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -112,6 +122,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		return jdbcTemplate.queryForObject("select count(*) from T_BEAN", Integer.class);
 	}
 
+	@Test
 	public void testFlowCommitsAfterMultipleRequests() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -144,6 +155,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testCancelEndState() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -166,6 +178,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testNoCommitAttributeSetOnEndState() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -185,6 +198,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testExceptionThrown() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -203,6 +217,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 
 	}
 
+	@Test
 	public void testExceptionThrownWithNothingBound() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -213,6 +228,7 @@ public class HibernateFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testLazyInitializedCollection() {
 		MockRequestContext context = new MockRequestContext();
 		MockFlowSession flowSession = new MockFlowSession();

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernateFlowManagedPersistenceIntegrationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernateFlowManagedPersistenceIntegrationTests.java
@@ -1,5 +1,8 @@
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import javax.sql.DataSource;
 
 import org.hibernate.Session;

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernatePersistenceContextPropagationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/HibernatePersistenceContextPropagationTests.java
@@ -1,5 +1,9 @@
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import javax.sql.DataSource;
 
 import org.springframework.transaction.support.TransactionSynchronizationManager;

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaFlowExecutionListenerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaFlowExecutionListenerTests.java
@@ -1,11 +1,15 @@
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
@@ -21,7 +25,7 @@ import org.springframework.webflow.execution.FlowExecutionException;
 import org.springframework.webflow.test.MockFlowSession;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class JpaFlowExecutionListenerTests extends TestCase {
+public class JpaFlowExecutionListenerTests {
 
 	private EntityManagerFactory entityManagerFactory;
 
@@ -29,11 +33,8 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 
 	private JdbcTemplate jdbcTemplate;
 
-	public void testTemp() {
-
-	}
-
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		DataSource dataSource = getDataSource();
 		populateDataBase(dataSource);
 		jdbcTemplate = new JdbcTemplate(dataSource);
@@ -42,6 +43,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		jpaListener = new JpaFlowExecutionListener(entityManagerFactory, tm);
 	}
 
+	@Test
 	public void testFlowNotAPersistenceContext() {
 		MockRequestContext context = new MockRequestContext();
 		MockFlowSession flowSession = new MockFlowSession();
@@ -49,6 +51,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testFlowCommitsInSingleRequest() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -78,6 +81,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		return jdbcTemplate.queryForObject("select count(*) from T_BEAN", Integer.class);
 	}
 
+	@Test
 	public void testFlowCommitsAfterMultipleRequests() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -112,6 +116,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testCancelEndState() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -135,6 +140,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testNoCommitAttributeSetOnEndState() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -154,6 +160,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 		assertSessionNotBound();
 	}
 
+	@Test
 	public void testExceptionThrown() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();
@@ -173,6 +180,7 @@ public class JpaFlowExecutionListenerTests extends TestCase {
 
 	}
 
+	@Test
 	public void testExceptionThrownWithNothingBound() {
 		assertEquals("Table should only have one row", 1, getCount());
 		MockRequestContext context = new MockRequestContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaFlowManagedPersistenceIntegrationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaFlowManagedPersistenceIntegrationTests.java
@@ -1,5 +1,8 @@
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;

--- a/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaPersistenceContextPropagationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/persistence/JpaPersistenceContextPropagationTests.java
@@ -1,5 +1,9 @@
 package org.springframework.webflow.persistence;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;

--- a/spring-webflow/src/test/java/org/springframework/webflow/security/SecurityFlowExecutionListenerTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/security/SecurityFlowExecutionListenerTests.java
@@ -1,12 +1,13 @@
 package org.springframework.webflow.security;
 
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -24,8 +25,9 @@ import org.springframework.webflow.engine.support.DefaultTargetStateResolver;
 import org.springframework.webflow.execution.RequestContext;
 import org.springframework.webflow.test.MockRequestContext;
 
-public class SecurityFlowExecutionListenerTests extends TestCase {
+public class SecurityFlowExecutionListenerTests {
 
+	@Test
 	public void testSessionCreatingNoSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -33,6 +35,7 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.sessionCreating(context, definition);
 	}
 
+	@Test
 	public void testSessionCreatingWithSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -43,6 +46,7 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.sessionCreating(context, flow);
 	}
 
+	@Test
 	public void testStateEnteringNoSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -51,6 +55,7 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.stateEntering(context, state);
 	}
 
+	@Test
 	public void testStateEnteringWithSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -62,6 +67,7 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.stateEntering(context, state);
 	}
 
+	@Test
 	public void testTransitionExecutingNoSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -69,6 +75,7 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.transitionExecuting(context, transition);
 	}
 
+	@Test
 	public void testTransitionExecutingWithSecurity() {
 		SecurityFlowExecutionListener listener = new SecurityFlowExecutionListener();
 		RequestContext context = new MockRequestContext();
@@ -79,11 +86,13 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		listener.transitionExecuting(context, transition);
 	}
 
+	@Test
 	public void testDecideAnyAuthorized() {
 		configureSecurityContext();
 		new SecurityFlowExecutionListener().decide(getSecurityRuleAnyAuthorized(), this);
 	}
 
+	@Test
 	public void testDecideAnyDenied() {
 		configureSecurityContext();
 		try {
@@ -94,11 +103,13 @@ public class SecurityFlowExecutionListenerTests extends TestCase {
 		}
 	}
 
+	@Test
 	public void testDecideAllAuthorized() {
 		configureSecurityContext();
 		new SecurityFlowExecutionListener().decide(getSecurityRuleAllAuthorized(), this);
 	}
 
+	@Test
 	public void testDecideAllDenied() {
 		configureSecurityContext();
 		try {

--- a/spring-webflow/src/test/java/org/springframework/webflow/security/SecurityRuleTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/security/SecurityRuleTests.java
@@ -1,30 +1,36 @@
 package org.springframework.webflow.security;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
-import junit.framework.Assert;
-import junit.framework.TestCase;
+import org.junit.Test;
 
-public class SecurityRuleTests extends TestCase {
 
+public class SecurityRuleTests {
+
+	@Test
 	public void testConvertAttributesToCommaSeparatedString() {
 		Collection<String> attributes = new ArrayList<>();
 		attributes.add("ROLE_1");
 		attributes.add("ROLE_2");
-		Assert.assertEquals("ROLE_1, ROLE_2", SecurityRule.securityAttributesToCommaDelimitedList(attributes));
+		assertEquals("ROLE_1, ROLE_2", SecurityRule.securityAttributesToCommaDelimitedList(attributes));
 	}
 
+	@Test
 	public void testConvertAttributesFromCommaSeparatedString() {
 		Collection<String> attributes = SecurityRule.commaDelimitedListToSecurityAttributes(" ,,ROLE_1, ROLE_2");
-		Assert.assertEquals(2, attributes.size());
-		Assert.assertTrue(attributes.contains("ROLE_1"));
-		Assert.assertTrue(attributes.contains("ROLE_2"));
+		assertEquals(2, attributes.size());
+		assertTrue(attributes.contains("ROLE_1"));
+		assertTrue(attributes.contains("ROLE_2"));
 	}
 
+	@Test
 	public void testDefaultComparisonType() {
 		SecurityRule rule = new SecurityRule();
-		Assert.assertTrue(rule.getComparisonType() == SecurityRule.COMPARISON_ANY);
+		assertTrue(rule.getComparisonType() == SecurityRule.COMPARISON_ANY);
 	}
 
 }

--- a/spring-webflow/src/test/java/org/springframework/webflow/test/MockActionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/test/MockActionTests.java
@@ -1,11 +1,15 @@
 package org.springframework.webflow.test;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
 import org.springframework.webflow.core.collection.LocalAttributeMap;
 import org.springframework.webflow.execution.Event;
 
-public class MockActionTests extends TestCase {
+public class MockActionTests {
+	@Test
 	public void testMockActionExecute() {
 		MockAction action = new MockAction();
 		Event e = action.execute(new MockRequestContext());
@@ -13,6 +17,7 @@ public class MockActionTests extends TestCase {
 		assertTrue(e.getAttributes().isEmpty());
 	}
 
+	@Test
 	public void testMockActionExecuteCustomResult() {
 		MockAction action = new MockAction("foo");
 		Event e = action.execute(new MockRequestContext());
@@ -20,6 +25,7 @@ public class MockActionTests extends TestCase {
 		assertTrue(e.getAttributes().isEmpty());
 	}
 
+	@Test
 	public void testMockActionExecuteCustomResultAttributes() {
 		MockAction action = new MockAction("foo");
 		LocalAttributeMap<Object> resultAttributes = new LocalAttributeMap<>();

--- a/spring-webflow/src/test/java/org/springframework/webflow/test/SearchFlowExecutionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/test/SearchFlowExecutionTests.java
@@ -15,11 +15,12 @@
  */
 package org.springframework.webflow.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.binding.mapping.Mapper;
-import org.springframework.binding.mapping.MappingResults;
+import org.junit.Test;
 import org.springframework.webflow.config.FlowDefinitionResource;
 import org.springframework.webflow.config.FlowDefinitionResourceFactory;
 import org.springframework.webflow.context.ExternalContext;
@@ -37,12 +38,14 @@ public class SearchFlowExecutionTests extends AbstractXmlFlowExecutionTests {
 		return resourceFactory.createClassPathResource("search-flow.xml", getClass());
 	}
 
+	@Test
 	public void testStartFlow() {
 		ExternalContext context = new MockExternalContext();
 		startFlow(null, context);
 		assertCurrentStateEquals("enterCriteria");
 	}
 
+	@Test
 	public void testCriteriaSubmitSuccess() {
 		startFlow(null, new MockExternalContext());
 		MockExternalContext context = new MockExternalContext();
@@ -54,6 +57,7 @@ public class SearchFlowExecutionTests extends AbstractXmlFlowExecutionTests {
 		assertResponseWrittenEquals("searchResults", context);
 	}
 
+	@Test
 	public void testNewSearch() {
 		startFlow(null, new MockExternalContext());
 		MockExternalContext context = new MockExternalContext();
@@ -69,6 +73,7 @@ public class SearchFlowExecutionTests extends AbstractXmlFlowExecutionTests {
 		assertResponseWrittenEquals("searchCriteria", context);
 	}
 
+	@Test
 	public void testSelectValidResult() {
 		startFlow(null, new MockExternalContext());
 		MockExternalContext context = new MockExternalContext();

--- a/spring-webflow/src/test/java/org/springframework/webflow/upgrade/WebFlowUpgraderTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/upgrade/WebFlowUpgraderTests.java
@@ -1,10 +1,10 @@
 package org.springframework.webflow.upgrade;
 
-import junit.framework.TestCase;
-
+import org.junit.Test;
 import org.springframework.core.io.ClassPathResource;
 
-public class WebFlowUpgraderTests extends TestCase {
+public class WebFlowUpgraderTests {
+	@Test
 	public void testConvertFlow1() {
 		WebFlowUpgrader upgrader = new WebFlowUpgrader();
 		String result = upgrader.convert(new ClassPathResource("flow1.xml", getClass()));

--- a/spring-webflow/src/test/java/org/springframework/webflow/validation/BeanValidationHintResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/validation/BeanValidationHintResolverTests.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.webflow.validation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import javax.validation.groups.Default;
 
-import junit.framework.TestCase;
-
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.webflow.execution.FlowExecutionException;
 
 /**
@@ -26,14 +30,16 @@ import org.springframework.webflow.execution.FlowExecutionException;
  *
  * @author Rossen Stoyanchev
  */
-public class BeanValidationHintResolverTests extends TestCase {
+public class BeanValidationHintResolverTests {
 
 	private BeanValidationHintResolver resolver;
 
+	@Before
 	public void setUp() {
 		this.resolver = new BeanValidationHintResolver();
 	}
 
+	@Test
 	public void testResolveFullyQualifiedClassNameHint() {
 		String[] hints = new String[] { this.getClass().getName() };
 		Class<?>[] resolvedHints = this.resolver.resolveValidationHints(null, "flowId", "state1", hints);
@@ -43,6 +49,7 @@ public class BeanValidationHintResolverTests extends TestCase {
 		assertEquals(this.getClass(), resolvedHints[0]);
 	}
 
+	@Test
 	public void testResolveInnterTypeHints() {
 		String[] hints = new String[] {"default", "state1", "state2"};
 		Class<?>[] resolvedHints = this.resolver.resolveValidationHints(new TestModel(), "flowId", "state1", hints);
@@ -54,6 +61,7 @@ public class BeanValidationHintResolverTests extends TestCase {
 		assertEquals(TestModel.State2.class, resolvedHints[2]);
 	}
 
+	@Test
 	public void testResolveHintNoMatch() {
 		try {
 			this.resolver.resolveValidationHints(null, "flowId", "state1", new String[] { "foo" });

--- a/spring-webflow/src/test/java/org/springframework/webflow/validation/ValidationHelperTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/validation/ValidationHelperTests.java
@@ -15,8 +15,12 @@
  */
 package org.springframework.webflow.validation;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.springframework.binding.expression.support.StaticExpression;
 import org.springframework.binding.message.MessageContext;
 import org.springframework.binding.validation.ValidationContext;
@@ -34,7 +38,7 @@ import org.springframework.webflow.test.MockRequestControlContext;
 /**
  * Unit test for {@link ValidationHelper}
  */
-public class ValidationHelperTests extends TestCase {
+public class ValidationHelperTests {
 
 	private MockRequestControlContext requestContext;
 
@@ -45,13 +49,15 @@ public class ValidationHelperTests extends TestCase {
 	private DefaultMessageCodesResolver codesResolver;
 
 
-	protected void setUp() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		requestContext = new MockRequestControlContext();
 		eventId = "userEvent";
 		modelName = "model";
 		codesResolver = new DefaultMessageCodesResolver();
 	}
 
+	@Test
 	public void testValidateWithMessageContext() {
 		Object model = new StubModelMessageContext();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null, null, null);
@@ -62,6 +68,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(0, messages.getMessagesBySource("validationcontext").length);
 	}
 
+	@Test
 	public void testValidateWithValidationContext() {
 		Object model = new StubModelValidationContext();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
@@ -72,6 +79,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(1, messages.getMessagesBySource("validationcontext").length);
 	}
 
+	@Test
 	public void testValidateWithMessageContextForBeanValidator() {
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("modelValidator", StubModelMessageContext.class);
@@ -84,6 +92,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(1, messages.getMessagesBySource("messagecontext-external").length);
 	}
 
+	@Test
 	public void testValidateWithValidationContextForBeanValidator() {
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("modelValidator", StubModelValidationContext.class);
@@ -96,6 +105,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(1, messages.getMessagesBySource("validationcontext-external").length);
 	}
 
+	@Test
 	public void testValidateWithErrorsForBeanValidator() {
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("modelValidator", StubModelErrors.class);
@@ -108,6 +118,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(1, messages.getMessagesBySource("errors-external").length);
 	}
 
+	@Test
 	public void testValidateWithErrorsForBeanValidatorOverridden() {
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
 		applicationContext.registerSingleton("modelValidator", StubModelErrorsOverridden.class);
@@ -120,6 +131,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(1, messages.getMessagesBySource("validationcontext-external").length);
 	}
 
+	@Test
 	public void testStateAndFallbackModelValidationMethodInvoked() {
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
@@ -131,6 +143,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(model.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackModelValidationMethodInvoked() {
 		Model model = new Model();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
@@ -142,6 +155,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(model.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackErrorsModelValidationMethodInvoked() {
 		ErrorsModel model = new ErrorsModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
@@ -153,6 +167,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(model.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackModelErrorsValidationMethodInvoked() {
 		ErrorsModel model = new ErrorsModel();
 		ValidationHelper helper = new ValidationHelper(model, requestContext, eventId, modelName, null,
@@ -164,6 +179,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(model.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackValidatorInvoked() {
 		ModelValidator validator = new ModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -180,6 +196,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackValidatorInvokedForSubclass() {
 		ModelValidator validator = new ModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -196,6 +213,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackValidatorInvoked() {
 		ModelValidator validator = new ModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -212,6 +230,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackValidatorInvokedForSubclass() {
 		ModelValidator validator = new ModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -228,6 +247,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackLegacyValidatorInvoked() {
 		LegacyModelValidator validator = new LegacyModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -244,6 +264,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackLegacyValidatorInvokedForSubclass() {
 		LegacyModelValidator validator = new LegacyModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -260,6 +281,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackLegacyValidatorInvoked() {
 		LegacyModelValidator validator = new LegacyModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -276,6 +298,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackErrorsValidatorInvoked() {
 		ErrorsModelValidator validator = new ErrorsModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -292,6 +315,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testStateAndFallbackErrorsValidatorInvokedForSubclass() {
 		ErrorsModelValidator validator = new ErrorsModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -308,6 +332,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackErrorsValidatorInvoked() {
 		ErrorsModelValidator validator = new ErrorsModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -324,6 +349,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testFallbackErrorsValidatorInvokedForSubclass() {
 		ErrorsModelValidator validator = new ErrorsModelValidator();
 		StaticApplicationContext applicationContext = new StaticApplicationContext();
@@ -340,6 +366,7 @@ public class ValidationHelperTests extends TestCase {
 		assertTrue(validator.fallbackInvoked);
 	}
 
+	@Test
 	public void testSmartValidatorWithClassHint() {
 		ViewState state = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		state.getAttributes().put("validationHints", new StaticExpression(new Object[] { Model.State1.class }));
@@ -357,6 +384,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(Model.State1.class, validator.hints[0]);
 	}
 
+	@Test
 	public void testSmartValidatorWithHintResolution() {
 		ViewState state = new ViewState(requestContext.getRootFlow(), "state2", new StubViewFactory());
 		state.getAttributes().put("validationHints", new StaticExpression("State1"));
@@ -374,6 +402,7 @@ public class ValidationHelperTests extends TestCase {
 		assertEquals(Model.State1.class, validator.hints[0]);
 	}
 
+	@Test
 	public void testSmartValidatorWithHintOnTransition() {
 		Transition transition = new Transition();
 		transition.setMatchingCriteria(new DefaultTransitionCriteria(new StaticExpression(eventId)));

--- a/spring-webflow/src/test/java/org/springframework/webflow/validation/WebFlowMessageResolverTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/validation/WebFlowMessageResolverTests.java
@@ -1,10 +1,13 @@
 package org.springframework.webflow.validation;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
 
-public class WebFlowMessageResolverTests extends TestCase {
+import org.junit.Test;
+
+public class WebFlowMessageResolverTests {
 	private WebFlowMessageCodesResolver messageCodesResolver = new WebFlowMessageCodesResolver();
 
+	@Test
 	public void testResolveObjectMessageCodes() {
 		String[] codes = messageCodesResolver.resolveMessageCodes("required", "testBean");
 		assertEquals(2, codes.length);
@@ -12,6 +15,7 @@ public class WebFlowMessageResolverTests extends TestCase {
 		assertEquals("required", codes[1]);
 	}
 
+	@Test
 	public void testResolveObjectMessageCodesWithPrefix() {
 		messageCodesResolver.setPrefix("validation.");
 		String[] codes = messageCodesResolver.resolveMessageCodes("required", "testBean");
@@ -20,6 +24,7 @@ public class WebFlowMessageResolverTests extends TestCase {
 		assertEquals("validation.required", codes[1]);
 	}
 
+	@Test
 	public void testResolveFieldMessageCodes() {
 		String[] codes = messageCodesResolver.resolveMessageCodes("required", "testBean", "foo", String.class);
 		assertEquals(4, codes.length);
@@ -29,6 +34,7 @@ public class WebFlowMessageResolverTests extends TestCase {
 		assertEquals("required", codes[3]);
 	}
 
+	@Test
 	public void testResolveFieldMessageCodesKeyedField() {
 		String[] codes = messageCodesResolver.resolveMessageCodes("required", "testBean", "foo[0]", String.class);
 		assertEquals(6, codes.length);
@@ -40,6 +46,7 @@ public class WebFlowMessageResolverTests extends TestCase {
 		assertEquals("required", codes[5]);
 	}
 
+	@Test
 	public void testResolveFieldMessageCodesWithPrefix() {
 		messageCodesResolver.setPrefix("validation.");
 		String[] codes = messageCodesResolver.resolveMessageCodes("required", "testBean", "foo", String.class);


### PR DESCRIPTION
JUnit version 5 has been out for a while so it's time to upgrade from version 3 to 4, right? ;)

My end goal with this is to remove `AbstractFlowExecutionTests`'s inheritance on JUnit 3's `TestCase` which causes all sorts of weirdness in my tests using Spring Webflow with JUnit 4 (need to use `@RunWith(JUnit4.class)`). This prevents my flow tests from using JUnit 5.