### PR TITLE
Provide testing support for JUnit 4 and 5

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
@@ -37,7 +37,9 @@ import org.springframework.webflow.test.MockFlowBuilderContext;
  * 
  * @author Keith Donald
  * @author Scott Andrews
+ * @deprecated
  */
+@Deprecated
 public abstract class AbstractExternalizedFlowExecutionTests extends AbstractFlowExecutionTests {
 
 	/**
@@ -140,6 +142,7 @@ public abstract class AbstractExternalizedFlowExecutionTests extends AbstractFlo
 		return new DefaultResourceLoader();
 	}
 
+	@Override
 	protected final FlowDefinition getFlowDefinition() {
 		if (isCacheFlowDefinition() && cachedFlowDefinition != null) {
 			return cachedFlowDefinition;

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
@@ -52,7 +52,9 @@ import org.springframework.webflow.test.MockExternalContext;
  * typically with a mock service layer.
  * 
  * @author Keith Donald
+ * @deprecated
  */
+@Deprecated
 public abstract class AbstractFlowExecutionTests extends TestCase {
 
 	/**

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
@@ -55,7 +55,9 @@ import org.springframework.webflow.engine.model.registry.FlowModelRegistryImpl;
  * @author Keith Donald
  * @author Erwin Vervaet
  * @author Scott Andrews
+ * @deprecated
  */
+@Deprecated
 public abstract class AbstractXmlFlowExecutionTests extends AbstractExternalizedFlowExecutionTests {
 
 	private FlowModelRegistry flowModelRegistry = new FlowModelRegistryImpl();
@@ -76,12 +78,14 @@ public abstract class AbstractXmlFlowExecutionTests extends AbstractExternalized
 		super(name);
 	}
 
+	@Override
 	protected final FlowBuilder createFlowBuilder(FlowDefinitionResource resource) {
 		registerDependentFlowModels();
 		FlowModelBuilder modelBuilder = new XmlFlowModelBuilder(resource.getPath(), flowModelRegistry);
 		FlowModelHolder modelHolder = new DefaultFlowModelHolder(modelBuilder);
 		flowModelRegistry.registerFlowModel(resource.getId(), modelHolder);
 		return new FlowModelFlowBuilder(modelHolder) {
+			@Override
 			protected void registerFlowBeans(ConfigurableBeanFactory flowBeanFactory) {
 				registerMockFlowBeans(flowBeanFactory);
 			}


### PR DESCRIPTION
As discussed in #97 and [SWF-1740](https://jira.spring.io/browse/SWF-1740), deprecate JUnit3-based testing support and provide replacements for JUnit versions 4 and 5.