### PR TITLE
Allow custom build of Flow ApplicationContext.

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilder.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/builder/model/FlowModelFlowBuilder.java
@@ -263,7 +263,7 @@ public class FlowModelFlowBuilder extends AbstractFlowBuilder {
 	public boolean hasFlowChanged() {
 		return flowModelHolder.hasFlowModelChanged();
 	}
-
+	
 	public String getFlowResourceString() {
 		return flowModelHolder.getFlowModelResource().getDescription();
 	}
@@ -282,6 +282,10 @@ public class FlowModelFlowBuilder extends AbstractFlowBuilder {
 
 	protected FlowModel getFlowModel() {
 		return flowModel;
+	}
+
+	protected FlowModelHolder getFlowModelHolder() {
+		return flowModelHolder;
 	}
 
 	protected LocalFlowBuilderContext getLocalContext() {
@@ -303,11 +307,23 @@ public class FlowModelFlowBuilder extends AbstractFlowBuilder {
 	protected void registerFlowBeans(ConfigurableBeanFactory beanFactory) {
 	}
 
+	/**
+	 * Build a {@link GenericApplicationContext} for the flow definition being build.
+	 * 
+	 * <p>Subclasses may override this method to fully control the nature and behavior of the
+	 * Spring context for the flow.</p>
+	 * 
+	 * @return the built and refreshed context
+	 */
+	protected GenericApplicationContext createFlowApplicationContext() {
+		Resource[] contextResources = parseContextResources(getFlowModel().getBeanImports());
+		return createFlowApplicationContext(contextResources);
+	}
+	
 	// internal helpers
 
 	private void initLocalFlowContext() {
-		Resource[] contextResources = parseContextResources(getFlowModel().getBeanImports());
-		GenericApplicationContext flowContext = createFlowApplicationContext(contextResources);
+		GenericApplicationContext flowContext = createFlowApplicationContext();
 		setLocalContext(new LocalFlowBuilderContext(getContext(), flowContext));
 	}
 


### PR DESCRIPTION
This is the first (possibly only, may have a second) PR from the Shibboleth Project that we'd like to see added to the milestone for SWF 3 that will help us eliminate some local duplication we needed, and I was able to shrink it down to a pretty simple and I think attractive change.

This just exposes a protected method on FlowModelFlowBuilder that allows the ApplicationContext to be custom-build by subclassing that one method. The default implementation just calls the pre-existing private methods that were being used originally.

This should be "subclasser-beware", obviously, it's understood that if you create your own context without considering what SWF does for itself, you're risking breakage.