### PR TITLE
Fix FlowSessionImpl serialization after deserialization

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/impl/FlowSessionImpl.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/impl/FlowSessionImpl.java
@@ -157,7 +157,7 @@ class FlowSessionImpl implements FlowSession, Externalizable {
 	}
 
 	public void writeExternal(ObjectOutput out) throws IOException {
-		out.writeObject(flow.getId());
+		out.writeObject(flow != null ? flow.getId() : null);
 		out.writeObject(state != null ? state.getId() : null);
 		out.writeObject(scope);
 		out.writeObject(parent);


### PR DESCRIPTION
This update fix serialization issue when server need to serialize `FlowSessionImpl.java` after `deserialization`.
In this flow server throws NPE in line 160 because deserialization not restores `flow` value. Instead of this it set only `flowId`value.
The issue exists in 2.5.1.RELEASE and 3.0.0-RC1.

This error is easy to reproduce with jetty server and enabled module `session-store-jdbc` and `session-cache-null`.



