### PR TITLE
Upgrade com.gradle.enterprise plugin to 3.16.2

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,8 +6,8 @@ pluginManagement {
 }
 
 plugins {
-	id 'com.gradle.enterprise' version '3.14.1'
-	id 'io.spring.ge.conventions' version '0.0.14'
+	id 'com.gradle.enterprise' version '3.16.2'
+	id 'io.spring.ge.conventions' version '0.0.15'
 }
 
 rootProject.name = 'webflow'


### PR DESCRIPTION
# Upgrade Enterprise Gradle Plugin

## Bumps
- [com.gradle.enterprise](https://plugins.gradle.org/plugin/com.gradle.enterprise) from 3.14.1 to 3.16.2
- [io.spring.ge.conventions](https://github.com/spring-io/gradle-enterprise-conventions) from 0.0.14 to 0.0.15

## Compatibility
Based on commits in spring-framework repo, internally spring team should support latest Gradle Enterprise plugin:
- Commit with note that only 3.15 version is supported: spring-projects/spring-framework@e3f185a696b0d6ca017a83366f24ed692573d14e 
- Commit with 3.16 version: spring-projects/spring-framework@b7e4fa16cae5f5a45fd661c51d558c8b9e5c39ae