### PR TITLE
Fix `ActionPropertyAccessor` on Spring Framework 6.2

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/action/DispatchMethodInvoker.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/action/DispatchMethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2012 the original author or authors.
+ * Copyright 2004-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,12 +48,13 @@ class DispatchMethodInvoker {
 	 */
 	@SuppressWarnings("serial")
 	private Map<String, Method> methodCache = new AbstractCachingMapDecorator<String, Method>() {
+		@Override
 		public Method create(String key) {
 			String methodName = key;
 			try {
 				return new MethodKey(target.getClass(), methodName, parameterTypes).getMethod();
 			} catch (InvalidMethodKeyException e) {
-				throw new MethodLookupException("Unable to resolve dispatch method " + e.getMethodKey()
+				throw new MethodLookupException("Unable to resolve dispatch method '" + e.getMethodKey()
 						+ "'; make sure the method name is correct and such a method is defined on targetClass "
 						+ target.getClass().getName(), e);
 			}

--- a/spring-webflow/src/main/java/org/springframework/webflow/expression/spel/ActionPropertyAccessor.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/expression/spel/ActionPropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2004-2012 the original author or authors.
+ * Copyright 2004-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,32 +28,37 @@ import org.springframework.webflow.execution.AnnotatedAction;
  * Spring EL Property Accessor that allows invocation of methods against a resolved Web Flow action, typically a
  * {@link MultiAction} in expressions.
  * </p>
- * 
+ *
  * @see org.springframework.webflow.action.EvaluateAction
- * 
+ *
  * @author Rossen Stoyanchev
  * @since 2.1
  */
 public class ActionPropertyAccessor implements PropertyAccessor {
 
+	@Override
 	public Class<?>[] getSpecificTargetClasses() {
 		return new Class[] { Action.class };
 	}
 
+	@Override
 	public boolean canRead(EvaluationContext context, Object target, String name) {
 		return true;
 	}
 
+	@Override
 	public TypedValue read(EvaluationContext context, Object target, String name) {
 		AnnotatedAction annotated = new AnnotatedAction((Action) target);
 		annotated.setMethod(name);
 		return new TypedValue(annotated);
 	}
 
+	@Override
 	public boolean canWrite(EvaluationContext context, Object target, String name) {
 		return false;
 	}
 
+	@Override
 	public void write(EvaluationContext context, Object target, String name, Object newValue) throws AccessException {
 		throw new AccessException("The Action cannot be set with an expression.");
 	}

--- a/spring-webflow/src/main/java/org/springframework/webflow/expression/spel/ActionPropertyAccessor.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/expression/spel/ActionPropertyAccessor.java
@@ -15,13 +15,17 @@
  */
 package org.springframework.webflow.expression.spel;
 
+import java.lang.reflect.Method;
+
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.webflow.action.MultiAction;
 import org.springframework.webflow.execution.Action;
 import org.springframework.webflow.execution.AnnotatedAction;
+import org.springframework.webflow.execution.RequestContext;
 
 /**
  * <p>
@@ -32,6 +36,7 @@ import org.springframework.webflow.execution.AnnotatedAction;
  * @see org.springframework.webflow.action.EvaluateAction
  *
  * @author Rossen Stoyanchev
+ * @author Sam Brannen
  * @since 2.1
  */
 public class ActionPropertyAccessor implements PropertyAccessor {
@@ -43,7 +48,16 @@ public class ActionPropertyAccessor implements PropertyAccessor {
 
 	@Override
 	public boolean canRead(EvaluationContext context, Object target, String name) {
-		return true;
+		// Ensure the target is an Action.
+		if (!(target instanceof Action)) {
+			return false;
+		}
+		// Ensure the method adheres to the signature required by:
+		// Action: execute(RequestContext)
+		// or
+		// MultiAction: <method name>(RequestContext)
+		Method method = ReflectionUtils.findMethod(target.getClass(), name, RequestContext.class);
+		return (method != null);
 	}
 
 	@Override

--- a/spring-webflow/src/test/java/org/springframework/webflow/action/MultiActionIntegrationTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/action/MultiActionIntegrationTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2004-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.webflow.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.webflow.config.AbstractFlowConfiguration;
+import org.springframework.webflow.definition.registry.FlowDefinitionRegistry;
+import org.springframework.webflow.execution.Event;
+import org.springframework.webflow.execution.RequestContext;
+import org.springframework.webflow.executor.FlowExecutor;
+import org.springframework.webflow.test.MockExternalContext;
+
+/**
+ * Integration tests for {@link MultiAction}.
+ *
+ * @author Sam Brannen
+ * @since 3.0.1
+ * @see <a href="https://github.com/spring-projects/spring-webflow/issues/1802">gh-1802</a>
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class MultiActionIntegrationTests {
+
+	private static final String WITH_REQUEST_CONTEXT = "withRequestContext";
+
+	private static final String WITHOUT_REQUEST_CONTEXT = "withoutRequestContext";
+
+
+	@Autowired
+	FlowExecutor flowExecutor;
+
+	@Autowired
+	CountingMultiAction multiAction;
+
+
+	@BeforeEach
+	void resetCounters() {
+		multiAction.counterWithRequestContext = 0;
+		multiAction.counterWithoutRequestContext = 0;
+	}
+
+	@Test
+	void spelExpressionsWithRequestContext() {
+		assertCounters(0, 0);
+		launchFlowExecution(WITH_REQUEST_CONTEXT);
+		assertCounters(2, 0);
+	}
+
+	@Test
+	void spelExpressionsWithoutRequestContext() {
+		assertCounters(0, 0);
+		launchFlowExecution(WITHOUT_REQUEST_CONTEXT);
+		assertCounters(0, 2);
+	}
+
+	private void launchFlowExecution(String flowId) {
+		flowExecutor.launchExecution(flowId, null, new MockExternalContext());
+	}
+
+	private void assertCounters(int counterWithRequestContext, int counterWithoutRequestContext) {
+		assertEquals(counterWithRequestContext, multiAction.counterWithRequestContext, "counterWithRequestContext");
+		assertEquals(counterWithoutRequestContext, multiAction.counterWithoutRequestContext, "counterWithoutRequestContext");
+	}
+
+
+
+	@Configuration
+	static class WebFlowConfig extends AbstractFlowConfiguration {
+
+		@Bean
+		CountingMultiAction countingMultiAction() {
+			return new CountingMultiAction();
+		}
+
+		@Bean
+		FlowExecutor flowExecutor() {
+			return getFlowExecutorBuilder(flowRegistry()).build();
+		}
+
+		@Bean
+		FlowDefinitionRegistry flowRegistry() {
+			return getFlowDefinitionRegistryBuilder()
+					.setBasePath("classpath:/org/springframework/webflow/action")
+					.addFlowLocation("multi-action-with-request-context.xml", WITH_REQUEST_CONTEXT)
+					.addFlowLocation("multi-action-without-request-context.xml", WITHOUT_REQUEST_CONTEXT)
+					.build();
+		}
+	}
+
+	@Component("countingMultiAction")
+	static class CountingMultiAction extends MultiAction {
+
+		int counterWithRequestContext = 0;
+
+		int counterWithoutRequestContext = 0;
+
+		public Event incrementWithRequestContext(RequestContext context) {
+			counterWithRequestContext++;
+			return success();
+		}
+
+		public Event incrementWithoutRequestContext() {
+			counterWithoutRequestContext++;
+			return success();
+		}
+	}
+
+}

--- a/spring-webflow/src/test/resources/org/springframework/webflow/action/multi-action-with-request-context.xml
+++ b/spring-webflow/src/test/resources/org/springframework/webflow/action/multi-action-with-request-context.xml
@@ -1,0 +1,15 @@
+<flow xmlns="http://www.springframework.org/schema/webflow"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.springframework.org/schema/webflow https://www.springframework.org/schema/webflow/spring-webflow.xsd">
+
+	<on-start>
+		<!-- Property Access: handled by org.springframework.webflow.expression.spel.ActionPropertyAccessor -->
+		<evaluate expression="countingMultiAction.incrementWithRequestContext" />
+
+		<!-- Method Invocation: handled by org.springframework.expression.spel.ast.MethodReference -->
+		<evaluate expression="countingMultiAction.incrementWithRequestContext(#requestContext)" />
+	</on-start>
+
+	<end-state id="end" />
+
+</flow>

--- a/spring-webflow/src/test/resources/org/springframework/webflow/action/multi-action-without-request-context.xml
+++ b/spring-webflow/src/test/resources/org/springframework/webflow/action/multi-action-without-request-context.xml
@@ -1,0 +1,15 @@
+<flow xmlns="http://www.springframework.org/schema/webflow"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://www.springframework.org/schema/webflow https://www.springframework.org/schema/webflow/spring-webflow.xsd">
+
+	<on-start>
+		<!-- Property Access: handled by org.springframework.expression.spel.support.ReflectivePropertyAccessor -->
+		<evaluate expression="countingMultiAction.incrementWithoutRequestContext" />
+
+		<!-- Method Invocation: handled by org.springframework.expression.spel.ast.MethodReference -->
+		<evaluate expression="countingMultiAction.incrementWithoutRequestContext()" />
+	</on-start>
+
+	<end-state id="end" />
+
+</flow>


### PR DESCRIPTION
## Overview

Prior to this PR, if a Spring Expression Language (SpEL) expression did not include parentheses for a `MultiAction` method that does not accept a `RequestContext` argument, the flow would pass on Spring Framework versions prior to 6.2, but the same flow would fail on Spring Framework 6.2 M1 or later. The following is such an expression and is effectively a property reference which must be handled by a registered `PropertyAccessor`: `reportActions.evaluateReport`.

The reason for the change in behavior is that Spring Framework 6.2 M1 includes a bug fix for ordering SpEL `PropertyAccessor`s. That bug fix correctly results in Spring Web Flow's `ActionPropertyAccessor` being evaluated before SpEL's `ReflectivePropertyAccessor`. Consequently, an expression such as `reportActions.evaluateReport` is now handled by `ActionPropertyAccessor` which indirectly requires that the action method accept a `RequestContext` argument. When the method does not accept a `RequestContext` argument, the flow fails with a `NoSuchMethodException`.

To address that, this PR revises the implementation of `canRead(...)` in `ActionPropertyAccessor` so that it only returns `true` if the action method accepts a `RequestContext` argument. When `ActionPropertyAccessor`'s `canRead(...)` method returns `false`, the generic `ReflectivePropertyAccessor` will be used instead, which restores the pre-6.2 behavior for such expressions.

The test suite passes for the following Spring Framework versions.

- `./gradlew -PspringFrameworkVersion=6.0.23 --rerun-tasks clean check`
- `./gradlew -PspringFrameworkVersion=6.1.14 --rerun-tasks clean check`
- `./gradlew -PspringFrameworkVersion=6.2.0-RC3 --rerun-tasks clean check`

## Related Issues

- spring-projects/spring-framework#33861
- spring-projects/spring-framework#33862
- #1802
