### PR TITLE
Upgrade abstract flow execution tests from JUnit 4 to JUnit 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ allprojects {
 			}
 			dependency "org.slf4j:slf4j-api:2.0.17"
 
-			dependency("junit:junit:4.13.2")
 			dependency "org.easymock:easymock:5.6.0"
 			dependency "org.hamcrest:hamcrest:3.0"
 			dependency "org.apache.tomcat:tomcat-jasper-el:10.1.31"

--- a/spring-webflow/spring-webflow.gradle
+++ b/spring-webflow/spring-webflow.gradle
@@ -7,14 +7,13 @@ dependencies {
 
 	compileOnly("jakarta.el:jakarta.el-api")
 	compileOnly("jakarta.servlet:jakarta.servlet-api")
-	compileOnly("junit:junit")
+	compileOnly("org.junit.jupiter:junit-jupiter-api")
 
 	optional("org.hibernate.orm:hibernate-core")
 	optional("org.springframework.security:spring-security-core")
 	optional("org.springframework:spring-orm")
 	optional("org.springframework:spring-tx")
 
-	testImplementation("junit:junit")
 	testImplementation("org.junit.jupiter:junit-jupiter")
 	testImplementation("org.easymock:easymock")
 	testImplementation("org.apache.tomcat:tomcat-jasper-el")

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractExternalizedFlowExecutionTests.java
@@ -63,18 +63,8 @@ public abstract class AbstractExternalizedFlowExecutionTests extends AbstractFlo
 
 	/**
 	 * Constructs a default externalized flow execution test.
-	 * @see #setName(String)
 	 */
 	public AbstractExternalizedFlowExecutionTests() {
-		init();
-	}
-
-	/**
-	 * Constructs an externalized flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractExternalizedFlowExecutionTests(String name) {
-		super(name);
 		init();
 	}
 

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractFlowExecutionTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.webflow.test.execution;
 
-import junit.framework.TestCase;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.springframework.util.Assert;
 import org.springframework.webflow.context.ExternalContext;
@@ -53,7 +53,7 @@ import org.springframework.webflow.test.MockExternalContext;
  * 
  * @author Keith Donald
  */
-public abstract class AbstractFlowExecutionTests extends TestCase {
+public abstract class AbstractFlowExecutionTests {
 
 	/**
 	 * The factory that will create the flow execution to test.
@@ -72,18 +72,9 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 
 	/**
 	 * Constructs a default flow execution test.
-	 * @see #setName(String)
 	 */
 	public AbstractFlowExecutionTests() {
 		super();
-	}
-
-	/**
-	 * Constructs a flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractFlowExecutionTests(String name) {
-		super(name);
 	}
 
 	/**
@@ -297,7 +288,7 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 	 * Assert that the entire flow execution is active; that is, it has not ended and has been started.
 	 */
 	protected void assertFlowExecutionActive() {
-		assertTrue("The flow execution is not active but it should be", getFlowExecution().isActive());
+		assertTrue(getFlowExecution().isActive(), "The flow execution is not active but it should be");
 	}
 
 	/**
@@ -314,7 +305,7 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 	 * Assert that the flow execution has ended; that is, it is no longer active.
 	 */
 	protected void assertFlowExecutionEnded() {
-		assertTrue("The flow execution is still active but it should have ended", getFlowExecution().hasEnded());
+		assertTrue(getFlowExecution().hasEnded(), "The flow execution is still active but it should have ended");
 	}
 
 	/**
@@ -322,8 +313,8 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 	 * @param outcome the name of the flow execution outcome
 	 */
 	protected void assertFlowExecutionOutcomeEquals(String outcome) {
-		assertNotNull("There has been no flow execution outcome", flowExecutionOutcome);
-		assertEquals("The flow execution outcome is wrong", outcome, flowExecutionOutcome.getId());
+		assertNotNull(flowExecutionOutcome, "There has been no flow execution outcome");
+		assertEquals(outcome, flowExecutionOutcome.getId(), "The flow execution outcome is wrong");
 	}
 
 	/**
@@ -331,9 +322,10 @@ public abstract class AbstractFlowExecutionTests extends TestCase {
 	 * @param expectedCurrentStateId the expected current state
 	 */
 	protected void assertCurrentStateEquals(String expectedCurrentStateId) {
-		assertEquals("The current state '" + getFlowExecution().getActiveSession().getState().getId()
-				+ "' does not equal the expected state '" + expectedCurrentStateId + "'", expectedCurrentStateId,
-				getFlowExecution().getActiveSession().getState().getId());
+		assertEquals(expectedCurrentStateId,
+				getFlowExecution().getActiveSession().getState().getId(),
+				"The current state '" + getFlowExecution().getActiveSession().getState().getId()
+						+ "' does not equal the expected state '" + expectedCurrentStateId + "'");
 	}
 
 	/**

--- a/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/test/execution/AbstractXmlFlowExecutionTests.java
@@ -62,18 +62,9 @@ public abstract class AbstractXmlFlowExecutionTests extends AbstractExternalized
 
 	/**
 	 * Constructs a default XML flow execution test.
-	 * @see #setName(String)
 	 */
 	public AbstractXmlFlowExecutionTests() {
 		super();
-	}
-
-	/**
-	 * Constructs an XML flow execution test with given name.
-	 * @param name the name of the test
-	 */
-	public AbstractXmlFlowExecutionTests(String name) {
-		super(name);
 	}
 
 	protected final FlowBuilder createFlowBuilder(FlowDefinitionResource resource) {

--- a/spring-webflow/src/test/java/org/springframework/webflow/test/SearchFlowExecutionTests.java
+++ b/spring-webflow/src/test/java/org/springframework/webflow/test/SearchFlowExecutionTests.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.springframework.webflow.config.FlowDefinitionResource;
 import org.springframework.webflow.config.FlowDefinitionResourceFactory;
@@ -91,7 +92,7 @@ public class SearchFlowExecutionTests extends AbstractXmlFlowExecutionTests {
 	protected void configureFlowBuilderContext(MockFlowBuilderContext builderContext) {
 		Flow mockDetailFlow = new Flow("detail-flow");
 		mockDetailFlow.setInputMapper((source, target) -> {
-			assertEquals("id of value 1 not provided as input by calling search flow", 1L, ((AttributeMap<?>) source).get("id"));
+			assertEquals(1L, ((AttributeMap<?>) source).get("id"), "id of value 1 not provided as input by calling search flow");
 			return null;
 		});
 		// test responding to finish result


### PR DESCRIPTION
Testing the execution of a XML-based flow definition is achieved by extending AbstractXmlFlowExecutionTests.  This class is a subclass of JUnit4 TestCase.  

It might be preferable for this class and related classes in the org.springframework.webflow.test.execution package to run JUnit 6 tests and this PR upgrades the abstract classes in org.springframework.webflow.test.execution to use JUnit 6 and removes JUnit 4 dependency entirely from the configuration.

This will be a breaking change for anyone who currently extends AbstractXmlFlowExecutionTests to test their XML configuration. 