### PR TITLE
Fix 'occured' -> 'occurred' typos in Spring Web Flow Javadoc (10 files)

### DIFF
--- a/spring-webflow/src/main/java/org/springframework/webflow/action/AbstractAction.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/action/AbstractAction.java
@@ -215,7 +215,7 @@ public abstract class AbstractAction implements Action, InitializingBean {
 	 * @param context the action execution context, for accessing and setting data in "flow scope" or "request scope"
 	 * @return the non-<code>null</code> action result, in which case the <code>doExecute()</code> will not be called,
 	 * or <code>null</code> if the <code>doExecute()</code> method should be called to obtain the action result
-	 * @throws Exception an <b>unrecoverable</b> exception occured, either checked or unchecked
+	 * @throws Exception an <b>unrecoverable</b> exception occurred, either checked or unchecked
 	 */
 	protected Event doPreExecute(RequestContext context) throws Exception {
 		return null;
@@ -225,7 +225,7 @@ public abstract class AbstractAction implements Action, InitializingBean {
 	 * Template hook method subclasses should override to encapsulate their specific action execution logic.
 	 * @param context the action execution context, for accessing and setting data in "flow scope" or "request scope"
 	 * @return the action result event
-	 * @throws Exception an <b>unrecoverable</b> exception occured, either checked or unchecked
+	 * @throws Exception an <b>unrecoverable</b> exception occurred, either checked or unchecked
 	 */
 	protected abstract Event doExecute(RequestContext context) throws Exception;
 
@@ -235,7 +235,7 @@ public abstract class AbstractAction implements Action, InitializingBean {
 	 * <p>
 	 * This implementation does nothing.
 	 * @param context the action execution context, for accessing and setting data in "flow scope" or "request scope"
-	 * @throws Exception an <b>unrecoverable</b> exception occured, either checked or unchecked
+	 * @throws Exception an <b>unrecoverable</b> exception occurred, either checked or unchecked
 	 */
 	protected void doPostExecute(RequestContext context) throws Exception {
 	}

--- a/spring-webflow/src/main/java/org/springframework/webflow/action/FormAction.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/action/FormAction.java
@@ -507,7 +507,7 @@ public class FormAction extends MultiAction implements InitializingBean {
 	 * {@link #doBind(RequestContext, DataBinder)} hook.
 	 * @param context the action execution context, for accessing and setting data in "flow scope" or "request scope"
 	 * @return "success" if there are no binding errors, "error" otherwise
-	 * @throws Exception an <b>unrecoverable</b> exception occured, either checked or unchecked
+	 * @throws Exception an <b>unrecoverable</b> exception occurred, either checked or unchecked
 	 */
 	public Event bind(RequestContext context) throws Exception {
 		if (logger.isDebugEnabled()) {
@@ -529,7 +529,7 @@ public class FormAction extends MultiAction implements InitializingBean {
 	 * {@link #doValidate(RequestContext, Object, Errors)} hook.
 	 * @param context the action execution context, for accessing and setting data in "flow scope" or "request scope"
 	 * @return "success" if there are no validation errors, "error" otherwise
-	 * @throws Exception an <b>unrecoverable</b> exception occured, either checked or unchecked
+	 * @throws Exception an <b>unrecoverable</b> exception occurred, either checked or unchecked
 	 * @see #getValidator()
 	 */
 	public Event validate(RequestContext context) throws Exception {
@@ -561,7 +561,7 @@ public class FormAction extends MultiAction implements InitializingBean {
 	 * custom methods as part of a single action chain.
 	 * @param context the request context
 	 * @return "success" if the reset action completed successfully
-	 * @throws Exception if an exception occured
+	 * @throws Exception if an exception occurred
 	 * @see #createFormObject(RequestContext)
 	 */
 	public Event resetForm(RequestContext context) throws Exception {
@@ -576,7 +576,7 @@ public class FormAction extends MultiAction implements InitializingBean {
 	 * Create the new form object and put it in the configured {@link #getFormObjectScope() scope}.
 	 * @param context the flow execution request context
 	 * @return the new form object
-	 * @throws Exception an exception occured creating the form object
+	 * @throws Exception an exception occurred creating the form object
 	 */
 	private Object initFormObject(RequestContext context) throws Exception {
 		if (logger.isDebugEnabled()) {

--- a/spring-webflow/src/main/java/org/springframework/webflow/conversation/ConversationManager.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/conversation/ConversationManager.java
@@ -27,7 +27,7 @@ public interface ConversationManager {
 	 * Begin a new conversation.
 	 * @param conversationParameters descriptive conversation parameters
 	 * @return a service interface allowing access to the conversation context
-	 * @throws ConversationException an exception occured
+	 * @throws ConversationException an exception occurred
 	 */
 	Conversation beginConversation(ConversationParameters conversationParameters) throws ConversationException;
 
@@ -67,7 +67,7 @@ public interface ConversationManager {
 	 * {@link ConversationId#toString()}.
 	 * @param encodedId the encoded id
 	 * @return the parsed conversation id
-	 * @throws ConversationException an exception occured parsing the id
+	 * @throws ConversationException an exception occurred parsing the id
 	 */
 	ConversationId parseConversationId(String encodedId) throws ConversationException;
 }

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/NoMatchingTransitionException.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/NoMatchingTransitionException.java
@@ -21,7 +21,7 @@ import org.springframework.webflow.execution.FlowExecutionException;
 /**
  * Thrown when no transition can be matched given the occurence of an event in the context of a flow execution request.
  * <p>
- * Typically this happens because there is no "handler" transition for the last event that occured.
+ * Typically this happens because there is no "handler" transition for the last event that occurred.
  * 
  * @author Keith Donald
  * @author Erwin Vervaet
@@ -37,7 +37,7 @@ public class NoMatchingTransitionException extends FlowExecutionException {
 	 * Create a new no matching transition exception.
 	 * @param flowId the current flow
 	 * @param stateId the state that could not be transitioned out of
-	 * @param event the event that occured that could not be matched to a transition
+	 * @param event the event that occurred that could not be matched to a transition
 	 * @param message the message
 	 */
 	public NoMatchingTransitionException(String flowId, String stateId, Event event, String message) {
@@ -49,7 +49,7 @@ public class NoMatchingTransitionException extends FlowExecutionException {
 	 * Create a new no matching transition exception.
 	 * @param flowId the current flow
 	 * @param stateId the state that could not be transitioned out of
-	 * @param event the event that occured that could not be matched to a transition
+	 * @param event the event that occurred that could not be matched to a transition
 	 * @param message the message
 	 * @param cause the underlying cause
 	 */

--- a/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/DocumentLoader.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/engine/model/builder/xml/DocumentLoader.java
@@ -34,9 +34,9 @@ public interface DocumentLoader {
 	 * Load the XML-based document from the external resource.
 	 * @param resource the document resource
 	 * @return the loaded (parsed) document
-	 * @throws IOException an exception occured accessing the resource input stream
-	 * @throws ParserConfigurationException an exception occured building the document parser
-	 * @throws SAXException a error occured during document parsing
+	 * @throws IOException an exception occurred accessing the resource input stream
+	 * @throws ParserConfigurationException an exception occurred building the document parser
+	 * @throws SAXException a error occurred during document parsing
 	 */
 	Document loadDocument(Resource resource) throws IOException, ParserConfigurationException, SAXException;
 }

--- a/spring-webflow/src/main/java/org/springframework/webflow/execution/EnterStateVetoException.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/execution/EnterStateVetoException.java
@@ -34,7 +34,7 @@ public class EnterStateVetoException extends FlowExecutionException {
 	/**
 	 * Create a new enter state veto exception.
 	 * @param flowId the active flow
-	 * @param sourceStateId the current state when the veto operation occured
+	 * @param sourceStateId the current state when the veto operation occurred
 	 * @param vetoedStateId the state for which entering is vetoed
 	 * @param message a descriptive message
 	 */
@@ -46,7 +46,7 @@ public class EnterStateVetoException extends FlowExecutionException {
 	/**
 	 * Create a new enter state veto exception.
 	 * @param flowId the active flow
-	 * @param sourceStateId the current state when the veto operation occured
+	 * @param sourceStateId the current state when the veto operation occurred
 	 * @param vetoedStateId the state for which entering is vetoed
 	 * @param message a descriptive message
 	 * @param cause the underlying cause

--- a/spring-webflow/src/main/java/org/springframework/webflow/execution/FlowExecutionException.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/execution/FlowExecutionException.java
@@ -53,8 +53,8 @@ public class FlowExecutionException extends FlowException {
 
 	/**
 	 * Creates a new flow execution exception.
-	 * @param flowId the flow where the exception occured
-	 * @param stateId the state where the exception occured
+	 * @param flowId the flow where the exception occurred
+	 * @param stateId the state where the exception occurred
 	 * @param message a descriptive message
 	 * @param cause the root cause
 	 */
@@ -65,14 +65,14 @@ public class FlowExecutionException extends FlowException {
 	}
 
 	/**
-	 * Returns the id of the flow definition that was executing when this exception occured.
+	 * Returns the id of the flow definition that was executing when this exception occurred.
 	 */
 	public String getFlowId() {
 		return flowId;
 	}
 
 	/**
-	 * Returns the id of the state definition where the exception occured. Could be null if no state was active at the
+	 * Returns the id of the state definition where the exception occurred. Could be null if no state was active at the
 	 * time when the exception was thrown.
 	 */
 	public String getStateId() {

--- a/spring-webflow/src/main/java/org/springframework/webflow/execution/View.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/execution/View.java
@@ -42,7 +42,7 @@ public interface View {
 
 	/**
 	 * Render this view's content.
-	 * @throws IOException if an IO Exception occured rendering the view
+	 * @throws IOException if an IO Exception occurred rendering the view
 	 */
 	void render() throws IOException;
 

--- a/spring-webflow/src/main/java/org/springframework/webflow/execution/repository/FlowExecutionRepositoryException.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/execution/repository/FlowExecutionRepositoryException.java
@@ -18,7 +18,7 @@ package org.springframework.webflow.execution.repository;
 import org.springframework.webflow.core.FlowException;
 
 /**
- * The root of the {@link FlowExecutionRepository} exception hierarchy. Indicates a problem occured either saving,
+ * The root of the {@link FlowExecutionRepository} exception hierarchy. Indicates a problem occurred either saving,
  * restoring, or invalidating a managed flow execution.
  * 
  * @author Erwin Vervaet

--- a/spring-webflow/src/main/java/org/springframework/webflow/execution/repository/snapshot/SerializedFlowExecutionSnapshot.java
+++ b/spring-webflow/src/main/java/org/springframework/webflow/execution/repository/snapshot/SerializedFlowExecutionSnapshot.java
@@ -150,7 +150,7 @@ public class SerializedFlowExecutionSnapshot extends FlowExecutionSnapshot imple
 	/**
 	 * Return the flow execution data in its raw byte[] form. Will decompress if necessary.
 	 * @return the byte array
-	 * @throws IOException a problem occured with decompression
+	 * @throws IOException a problem occurred with decompression
 	 */
 	protected byte[] getFlowExecutionData() throws IOException {
 		if (isCompressed()) {


### PR DESCRIPTION
Fixes 24 instances of `occured` → `occurred` across 10 Javadoc files in `spring-webflow`. These are all documentation-only changes in method Javadoc, class-level Javadoc, and `@throws` clauses. No code, API, or behavior change.

## Files

| File | Instances |
|------|-----------|
| `FormAction.java` | 4 |
| `FlowExecutionException.java` | 4 |
| `AbstractAction.java` | 3 |
| `NoMatchingTransitionException.java` | 3 |
| `DocumentLoader.java` | 3 |
| `ConversationManager.java` | 2 |
| `EnterStateVetoException.java` | 2 |
| `View.java` | 1 |
| `FlowExecutionRepositoryException.java` | 1 |
| `SerializedFlowExecutionSnapshot.java` | 1 |

All fixes preserve the surrounding comment structure (Javadoc tags, line wrapping). No compiler or javadoc tool output change expected.

## Testing

Javadoc-only, no tests impacted. Spotted via repository-wide grep for the misspelling.